### PR TITLE
[PLA-1691] Ensure schema is not empty for multi-tokens when using dispatch.

### DIFF
--- a/src/Enums/DispatchCall.php
+++ b/src/Enums/DispatchCall.php
@@ -8,7 +8,7 @@ enum DispatchCall: string
 {
     use EnumExtensions;
 
-    case MULTI_TOKENS = '';
+    case MULTI_TOKENS = 'primary';
     case FUEL_TANKS = 'fuel-tanks';
     case MARKETPLACE = 'marketplace';
 }

--- a/src/Rules/ValidMutation.php
+++ b/src/Rules/ValidMutation.php
@@ -33,6 +33,7 @@ class ValidMutation implements DataAwareRule, ValidationRule
     {
         match (Arr::get($this->data, 'dispatch.call')) {
             DispatchCall::FUEL_TANKS->name => $this->validateQuery('fuel-tanks', $value, $fail),
+            DispatchCall::MARKETPLACE->name => $this->validateQuery('marketplace', $value, $fail),
             DispatchCall::MULTI_TOKENS->name => $this->validateQuery('primary', $value, $fail),
         };
     }

--- a/src/Services/Processor/Substrate/Codec/Codec.php
+++ b/src/Services/Processor/Substrate/Codec/Codec.php
@@ -22,7 +22,7 @@ class Codec extends BaseCodec
     /**
      * Get the encoder.
      */
-    public function encoder(): Encoder
+    public function encoder(): FuelTankEncoder
     {
         return $this->encoder;
     }
@@ -30,7 +30,7 @@ class Codec extends BaseCodec
     /**
      * Get the decoder.
      */
-    public function decoder(): Decoder
+    public function decoder(): FuelTankDecoder
     {
         return $this->decoder;
     }

--- a/testbench.yaml
+++ b/testbench.yaml
@@ -14,4 +14,5 @@ env:
   - DAEMON_ACCOUNT="0x68b427dda4f3894613e113b570d5878f3eee981196133e308c0a82584cf2e160"
 
 providers:
+  - Enjin\Platform\FuelTanks\FuelTanksServiceProvider
   - Enjin\Platform\CoreServiceProvider

--- a/tests/Feature/GraphQL/Resources/SetCollectionAttribute.graphql
+++ b/tests/Feature/GraphQL/Resources/SetCollectionAttribute.graphql
@@ -1,0 +1,14 @@
+mutation SetCollectionAttribute(
+    $collectionId: BigInt!
+    $key: String!
+    $value: String!
+) {
+    SetCollectionAttribute(
+        collectionId: $collectionId
+        key: $key
+        value: $value
+    ) {
+        id
+        encodedData
+    }
+}

--- a/tests/Unit/EncodingTest.php
+++ b/tests/Unit/EncodingTest.php
@@ -400,7 +400,7 @@ class EncodingTest extends TestCase
             ),
         );
 
-        $data = TransactionSerializer::encode('InsertRuleSet', InsertRulesetMutation::getEncodableParams(
+        $data = TransactionSerializer::encode('InsertRuleSet', InsertRuleSetMutation::getEncodableParams(
             tankId: '0x18353dcf7a6eb053b6f0c01774d1f8cfe0c15963780f6935c49a9fd4f50b893c',
             ruleSetId: '10',
             dispatchRules: $dispatchRules,
@@ -421,7 +421,7 @@ class EncodingTest extends TestCase
             ),
         );
 
-        $data = TransactionSerializer::encode('InsertRuleSet', InsertRulesetMutation::getEncodableParams(
+        $data = TransactionSerializer::encode('InsertRuleSet', InsertRuleSetMutation::getEncodableParams(
             tankId: '0x18353dcf7a6eb053b6f0c01774d1f8cfe0c15963780f6935c49a9fd4f50b893c',
             ruleSetId: '10',
             dispatchRules: $dispatchRules,
@@ -439,7 +439,7 @@ class EncodingTest extends TestCase
 
     public function test_it_can_encode_remove_rule_set()
     {
-        $data = TransactionSerializer::encode('RemoveRuleSet', RemoveRulesetmutation::getEncodableParams(
+        $data = TransactionSerializer::encode('RemoveRuleSet', RemoveRuleSetMutation::getEncodableParams(
             tankId: '0xd43593c715fdd31c61141abd04a99fd6822c8558854ccde39a5684e7a56da27d',
             ruleSetId: '10'
         ));


### PR DESCRIPTION
## **Type**
enhancement, bug_fix


___

## **Description**
- Updated `DispatchCall` enum to assign a proper value to `MULTI_TOKENS`.
- Enhanced codec service by specifying return types for encoder and decoder methods.
- Added a new test for dispatching multi tokens and updated parameter generation in `DispatchTest`.
- Corrected method call typos in `EncodingTest`.
- Registered `FuelTanksServiceProvider` in the test environment configuration.
- Introduced a new GraphQL mutation `SetCollectionAttribute` for setting collection attributes.


___



## **Changes walkthrough**
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>DispatchCall.php</strong><dd><code>Update DispatchCall Enum with Correct Value for MULTI_TOKENS</code></dd></summary>
<hr>

src/Enums/DispatchCall.php
<li>Changed the value of <code>MULTI_TOKENS</code> from an empty string to 'primary'.<br>


</details>
    

  </td>
  <td><a href="https://github.com/enjin/platform-fuel-tanks/pull/37/files#diff-d7401f8a7d08285e4274c55e14f994058dbd450ca14c4d4e936d4c3043800340">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>
</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>Codec.php</strong><dd><code>Update Codec Service with Specific Encoder and Decoder Types</code></dd></summary>
<hr>

src/Services/Processor/Substrate/Codec/Codec.php
<li>Changed the return type of <code>encoder()</code> to <code>FuelTankEncoder</code>.<br> <li> Changed the return type of <code>decoder()</code> to <code>FuelTankDecoder</code>.<br>


</details>
    

  </td>
  <td><a href="https://github.com/enjin/platform-fuel-tanks/pull/37/files#diff-197f92fefad62ef5ec31c3e1a4a86b8f3d8271e3b182a6c689c72ea0f254d0a8">+2/-2</a>&nbsp; &nbsp; &nbsp; </td>
</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>SetCollectionAttribute.graphql</strong><dd><code>Add GraphQL Mutation for Setting Collection Attributes</code>&nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

tests/Feature/GraphQL/Resources/SetCollectionAttribute.graphql
- Added a new GraphQL mutation `SetCollectionAttribute`.



</details>
    

  </td>
  <td><a href="https://github.com/enjin/platform-fuel-tanks/pull/37/files#diff-98a85e0688db9379fe43eba1a085ae9a6ccb37c61b154c88939eb06bfe4d11e8">+14/-0</a>&nbsp; &nbsp; </td>
</tr>                    
</table></td></tr><tr><td><strong>Tests</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>DispatchTest.php</strong><dd><code>Add Test for Multi-Token Dispatch and Update Parameter Generation</code></dd></summary>
<hr>

tests/Feature/GraphQL/Mutations/DispatchTest.php
<li>Added a new test <code>test_it_can_dispatch_multi_token</code> to verify dispatch <br>functionality for multi tokens.<br> <li> Modified <code>generateParams</code> method to support <code>DispatchCall::MULTI_TOKENS</code>.<br>


</details>
    

  </td>
  <td><a href="https://github.com/enjin/platform-fuel-tanks/pull/37/files#diff-f45ae48100ac40bb0749bbc12cfb17a4e0fedfda9d4bf486942b8e9185fd821a">+38/-6</a>&nbsp; &nbsp; </td>
</tr>                    
</table></td></tr><tr><td><strong>Bug_fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>EncodingTest.php</strong><dd><code>Fix Typo in EncodingTest Method Calls</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

tests/Unit/EncodingTest.php
<li>Fixed typo in method calls from <code>InsertRulesetMutation</code> to <br><code>InsertRuleSetMutation</code>.<br> <li> Fixed typo in method calls from <code>RemoveRulesetmutation</code> to <br><code>RemoveRuleSetMutation</code>.<br>


</details>
    

  </td>
  <td><a href="https://github.com/enjin/platform-fuel-tanks/pull/37/files#diff-304632780535cba1fc76d5ae4d6cfca20af64a2f1fb2e4a782300d6035017d2e">+3/-3</a>&nbsp; &nbsp; &nbsp; </td>
</tr>                    
</table></td></tr><tr><td><strong>Configuration changes</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>testbench.yaml</strong><dd><code>Register FuelTanksServiceProvider in Test Environment</code>&nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

testbench.yaml
- Added `FuelTanksServiceProvider` to the providers list.



</details>
    

  </td>
  <td><a href="https://github.com/enjin/platform-fuel-tanks/pull/37/files#diff-ef7834cd1991a169c5e09ee7b61b72255e1feabf34bb85a21c75fc6fa532917a">+1/-0</a>&nbsp; &nbsp; &nbsp; </td>
</tr>                    
</table></td></tr></tr></tbody></table>

___

> ✨ **PR-Agent usage**:
>Comment `/help` on the PR to get a list of all available PR-Agent tools and their descriptions

