### PR TITLE
[PLA-1806] Class init error

### DIFF
--- a/src/Services/Processor/Substrate/Events/Implementations/FuelTanks/FreezeStateMutated.php
+++ b/src/Services/Processor/Substrate/Events/Implementations/FuelTanks/FreezeStateMutated.php
@@ -25,7 +25,7 @@ class FreezeStateMutated extends FuelTankSubstrateEvent
         // Fail if it doesn't find the fuel tank
         $fuelTank = $this->getFuelTank($this->event->tankId);
 
-        if (is_null($this->event->ruleSetId)) {
+        if (empty($this->event->ruleSetId)) {
             $fuelTank->is_frozen = $this->event->isFrozen;
             $fuelTank->save();
 
@@ -40,7 +40,7 @@ class FreezeStateMutated extends FuelTankSubstrateEvent
 
     public function log(): void
     {
-        if (is_null($this->event->ruleSetId)) {
+        if (empty($this->event->ruleSetId)) {
             Log::debug(
                 sprintf(
                     'FuelTank %s was %s.',

--- a/src/Services/Processor/Substrate/Events/Implementations/FuelTanks/FreezeStateMutated.php
+++ b/src/Services/Processor/Substrate/Events/Implementations/FuelTanks/FreezeStateMutated.php
@@ -25,7 +25,7 @@ class FreezeStateMutated extends FuelTankSubstrateEvent
         // Fail if it doesn't find the fuel tank
         $fuelTank = $this->getFuelTank($this->event->tankId);
 
-        if (empty($this->event->ruleSetId)) {
+        if (is_null($this->event->ruleSetId)) {
             $fuelTank->is_frozen = $this->event->isFrozen;
             $fuelTank->save();
 
@@ -40,7 +40,7 @@ class FreezeStateMutated extends FuelTankSubstrateEvent
 
     public function log(): void
     {
-        if (empty($this->event->ruleSetId)) {
+        if (is_null($this->event->ruleSetId)) {
             Log::debug(
                 sprintf(
                     'FuelTank %s was %s.',

--- a/src/Services/Processor/Substrate/Events/Implementations/FuelTanks/FuelTankCreated.php
+++ b/src/Services/Processor/Substrate/Events/Implementations/FuelTanks/FuelTankCreated.php
@@ -18,7 +18,7 @@ class FuelTankCreated extends FuelTankSubstrateEvent
     /** @var FuelTankCreatedPolkadart */
     protected Event $event;
 
-    protected FuelTank $fuelTankCreated;
+    protected ?FuelTank $fuelTankCreated = null;
 
     /**
      * Handle the fuel tank created event.

--- a/src/Services/Processor/Substrate/Events/Implementations/FuelTanks/FuelTankMutated.php
+++ b/src/Services/Processor/Substrate/Events/Implementations/FuelTanks/FuelTankMutated.php
@@ -26,16 +26,16 @@ class FuelTankMutated extends FuelTankSubstrateEvent
         // Fail if it doesn't find the fuel tank
         $fuelTank = $this->getFuelTank($this->event->tankId);
 
-        if (!is_null($uac = $this->event->userAccountManagement)) {
+        if (!empty($uac = $this->event->userAccountManagement)) {
             $fuelTank->reserves_existential_deposit = $this->getValue($uac, ['Some.tank_reserves_existential_deposit', 'tank_reserves_existential_deposit']);
             $fuelTank->reserves_account_creation_deposit = $this->getValue($uac, ['Some.tank_reserves_account_creation_deposit', 'tank_reserves_account_creation_deposit']);
         }
 
-        if (!is_null($providesDeposit = $this->event->providesDeposit)) {
+        if (!empty($providesDeposit = $this->event->providesDeposit)) {
             $fuelTank->provides_deposit = $providesDeposit;
         }
 
-        if (!is_null($accountRules = $this->event->accountRules)) {
+        if (!empty($accountRules = $this->event->accountRules)) {
             AccountRule::where('fuel_tank_id', $fuelTank->id)?->delete();
 
             $insertAccountRules = [];


### PR DESCRIPTION
### **PR Type**
Bug fix


___

### **Description**
- Fixed a potential class initialization error by making the `FuelTank` property nullable and initializing it to `null`.


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix
</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>FuelTankCreated.php</strong><dd><code>Make `FuelTank` property nullable and initialize to null</code>&nbsp; </dd></summary>
<hr>

src/Services/Processor/Substrate/Events/Implementations/FuelTanks/FuelTankCreated.php
<li>Changed <code>FuelTank</code> property to be nullable.<br> <li> Initialized <code>FuelTank</code> property to <code>null</code>.<br>


</details>
    

  </td>
  <td><a href="https://github.com/enjin/platform-fuel-tanks/pull/46/files#diff-5daf1232afd3f8eabeb6863da0c3a2827986cfe0601569b613d145a39e1e4b23">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>
</tr>                    
</table></td></tr></tr></tbody></table>

___

> 💡 **PR-Agent usage**:
>Comment `/help` on the PR to get a list of all available PR-Agent tools and their descriptions

