### PR TITLE
[PLA-1882] Wrap codes with db transaction

### DIFF
--- a/src/GraphQL/Mutations/DispatchMutation.php
+++ b/src/GraphQL/Mutations/DispatchMutation.php
@@ -98,12 +98,12 @@ class DispatchMutation extends Mutation implements PlatformBlockchainTransaction
         ResolveInfo $resolveInfo,
         Closure $getSelectFields,
     ) {
+        DB::beginTransaction();
         $encodedCall = static::getFuelTankCall($this->getMethodName(), $args);
+        $transaction = $this->storeTransaction($args, $encodedCall);
+        DB::commit();
 
-        return Transaction::lazyLoadSelectFields(
-            DB::transaction(fn () => $this->storeTransaction($args, $encodedCall)),
-            $resolveInfo
-        );
+        return Transaction::lazyLoadSelectFields($transaction, $resolveInfo);
     }
 
     public static function getEncodedCall($args)


### PR DESCRIPTION
### **PR Type**
Bug fix


___

### **Description**
- Wrapped the `DispatchMutation` resolve method with explicit database transaction handling using `DB::beginTransaction()` and `DB::commit()`.
- Simplified the return statement by removing the nested transaction call and storing the transaction result in a variable.


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>DispatchMutation.php</strong><dd><code>Wrap DispatchMutation resolve method with database transaction</code></dd></summary>
<hr>

src/GraphQL/Mutations/DispatchMutation.php

<li>Wrapped code execution within a database transaction.<br> <li> Replaced inline transaction handling with explicit <br><code>DB::beginTransaction()</code> and <code>DB::commit()</code>.<br> <li> Simplified the return statement by removing the nested transaction <br>call.<br>


</details>


  </td>
  <td><a href="https://github.com/enjin/platform-fuel-tanks/pull/55/files#diff-87f5723a43a071591665152b45c9e01f47f2c3fa3317c936d45d5477cdaf9977">+4/-4</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    
</table></td></tr></tr></tbody></table>

___

> 💡 **PR-Agent usage**:
>Comment `/help` on the PR to get a list of all available PR-Agent tools and their descriptions

