### PR TITLE
[PLA-1900] Adds default value to provides deposit

### DIFF
--- a/src/Services/Processor/Substrate/Events/Implementations/FuelTanks/FuelTankCreated.php
+++ b/src/Services/Processor/Substrate/Events/Implementations/FuelTanks/FuelTankCreated.php
@@ -51,7 +51,7 @@ class FuelTankCreated extends FuelTankSubstrateEvent
                 'owner_wallet_id' => $owner->id,
                 'reserves_existential_deposit' => $reservesExistentialDeposit,
                 'reserves_account_creation_deposit' => $reservesAccountCreationDeposit,
-                'provides_deposit' => $providesDeposit,
+                'provides_deposit' => $providesDeposit ?? false,
                 'is_frozen' => false,
             ]
         );


### PR DESCRIPTION
### **PR Type**
Bug fix


___

### **Description**
- Added a default value of `false` to the `provides_deposit` field in the `FuelTankCreated` event to prevent potential null value issues.


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>FuelTankCreated.php</strong><dd><code>Add default value for `provides_deposit` field</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/Services/Processor/Substrate/Events/Implementations/FuelTanks/FuelTankCreated.php

- Added a default value of `false` to the `provides_deposit` field.



</details>


  </td>
  <td><a href="https://github.com/enjin/platform-fuel-tanks/pull/59/files#diff-5daf1232afd3f8eabeb6863da0c3a2827986cfe0601569b613d145a39e1e4b23">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    
</table></td></tr></tr></tbody></table>

___

> 💡 **PR-Agent usage**:
>Comment `/help` on the PR to get a list of all available PR-Agent tools and their descriptions

