### PR TITLE
[PLA-2056] Fix InsertRuleSet mutation

### DIFF
--- a/src/GraphQL/Mutations/InsertRuleSetMutation.php
+++ b/src/GraphQL/Mutations/InsertRuleSetMutation.php
@@ -96,10 +96,9 @@ class InsertRuleSetMutation extends Mutation implements PlatformBlockchainTransa
         SerializationServiceInterface $serializationService,
         Substrate $blockchainService
     ) {
-        $method = isRunningLatest() ? $this->getMutationName() . 'V1010' : $this->getMutationName();
         $dispatchRules = $blockchainService->getDispatchRulesParams($args['dispatchRules']);
         $encodedData = $serializationService->encode(
-            $method,
+            $this->getMutationName(),
             static::getEncodableParams(
                 tankId: $args['tankId'],
                 ruleSetId: $args['ruleSetId'],

--- a/src/GraphQL/Mutations/RemoveAccountRuleDataMutation.php
+++ b/src/GraphQL/Mutations/RemoveAccountRuleDataMutation.php
@@ -98,8 +98,7 @@ class RemoveAccountRuleDataMutation extends Mutation implements PlatformBlockcha
         Closure $getSelectFields,
         SerializationServiceInterface $serializationService
     ) {
-        $method = isRunningLatest() ? $this->getMutationName() . 'V1010' : $this->getMutationName();
-        $encodedData = $serializationService->encode($method, static::getEncodableParams(...$args));
+        $encodedData = $serializationService->encode($this->getMutationName(), static::getEncodableParams(...$args));
 
         return Transaction::lazyLoadSelectFields(
             DB::transaction(fn () => $this->storeTransaction($args, $encodedData)),


### PR DESCRIPTION
### **PR Type**
Bug fix


___

### **Description**
- Removed the conditional logic for selecting method names based on `isRunningLatest()` in `InsertRuleSetMutation` and `RemoveAccountRuleDataMutation`.
- Simplified the encoding process by directly using the mutation name.



___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>InsertRuleSetMutation.php</strong><dd><code>Simplify method name usage in InsertRuleSetMutation</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/GraphQL/Mutations/InsertRuleSetMutation.php

<li>Removed conditional method name selection based on <code>isRunningLatest()</code>.<br> <li> Simplified method name usage in <code>encode</code> function.<br>


</details>


  </td>
  <td><a href="https://github.com/enjin/platform-fuel-tanks/pull/68/files#diff-d9d2d25b651fb6dc4e8b1c7b2b648a3d61cdbf755a4a91374b3b950ceb772ab7">+1/-2</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>RemoveAccountRuleDataMutation.php</strong><dd><code>Simplify method name usage in RemoveAccountRuleDataMutation</code></dd></summary>
<hr>

src/GraphQL/Mutations/RemoveAccountRuleDataMutation.php

<li>Removed conditional method name selection based on <code>isRunningLatest()</code>.<br> <li> Simplified method name usage in <code>encode</code> function.<br>


</details>


  </td>
  <td><a href="https://github.com/enjin/platform-fuel-tanks/pull/68/files#diff-9a8b675ea19153d9ca6453cb838c795dfac302563d380032999c8cc18a619400">+1/-2</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    
</table></td></tr></tr></tbody></table>

___

> 💡 **PR-Agent usage**: Comment `/help "your question"` on any pull request to receive relevant information