### PR TITLE
[PLA-2059] Add RequireAccount to InsertRuleSet

### DIFF
--- a/src/GraphQL/Mutations/InsertRuleSetMutation.php
+++ b/src/GraphQL/Mutations/InsertRuleSetMutation.php
@@ -77,6 +77,11 @@ class InsertRuleSetMutation extends Mutation implements PlatformBlockchainTransa
                 'type' => GraphQL::type('DispatchRuleInputType!'),
                 'description' => __('enjin-platform-fuel-tanks::input_type.dispatch_rule.description'),
             ],
+            'requireAccount' => [
+                'type' => GraphQL::type('Boolean'),
+                'description' => __('enjin-platform-fuel-tanks::mutation.insert_rule_set.args.requireAccount'),
+                'defaultValue' => false,
+            ],
             ...$this->getSigningAccountField(),
             ...$this->getIdempotencyField(),
             ...$this->getSimulateField(),
@@ -102,7 +107,8 @@ class InsertRuleSetMutation extends Mutation implements PlatformBlockchainTransa
             static::getEncodableParams(
                 tankId: $args['tankId'],
                 ruleSetId: $args['ruleSetId'],
-                dispatchRules: $dispatchRules
+                dispatchRules: $dispatchRules,
+                requireAccount: $args['requireAccount'],
             )
         );
 
@@ -122,6 +128,7 @@ class InsertRuleSetMutation extends Mutation implements PlatformBlockchainTransa
         $tankId = Arr::get($params, 'tankId', Account::daemonPublicKey());
         $ruleSetId = Arr::get($params, 'ruleSetId', 0);
         $rules = Arr::get($params, 'dispatchRules', new DispatchRulesParams())->toEncodable();
+        $requireAccount = Arr::get($params, 'requireAccount', false);
 
         return [
             'tankId' => [
@@ -130,7 +137,7 @@ class InsertRuleSetMutation extends Mutation implements PlatformBlockchainTransa
             'ruleSetId' => $ruleSetId,
             'ruleSet' => [
                 'rules' => $rules,
-                'requireAccount' => false,
+                'requireAccount' => $requireAccount,
             ],
         ];
     }

--- a/tests/Feature/GraphQL/Mutations/InsertRuleSetTest.php
+++ b/tests/Feature/GraphQL/Mutations/InsertRuleSetTest.php
@@ -53,6 +53,28 @@ class InsertRuleSetTest extends TestCaseGraphQL
         );
     }
 
+    public function test_it_can_insert_rule_set_with_require_account(): void
+    {
+        $params = $this->generateRuleSet();
+        $params['requireAccount'] = true;
+
+        $response = $this->graphql(
+            $this->method,
+            $params
+        );
+
+        $params['dispatchRules'] = resolve(Substrate::class)->getDispatchRulesParams($params['dispatchRules']);
+
+        $encodedData = TransactionSerializer::encode($this->method, InsertRuleSetMutation::getEncodableParams(...$params));
+        $encodedData = Str::take($encodedData, Str::length($encodedData) - 4);
+        $encodedData .= Arr::get($params['dispatchRules']->permittedExtrinsics->toEncodable(), 'PermittedExtrinsics.extrinsics');
+
+        $this->assertEquals(
+            $response['encodedData'],
+            $encodedData
+        );
+    }
+
     public function test_it_can_skip_validation(): void
     {
         $response = $this->graphql(

--- a/tests/Feature/GraphQL/Resources/InsertRuleSet.graphql
+++ b/tests/Feature/GraphQL/Resources/InsertRuleSet.graphql
@@ -2,12 +2,14 @@ mutation InsertRuleSet(
   $tankId: String!
   $ruleSetId: BigInt!
   $dispatchRules: DispatchRuleInputType!
+  $requireAccount: Boolean
   $skipValidation: Boolean
 ) {
   InsertRuleSet(
     tankId: $tankId
     ruleSetId: $ruleSetId
     dispatchRules: $dispatchRules
+    requireAccount: $requireAccount
     skipValidation: $skipValidation
   ) {
     id

--- a/tests/Unit/EncodingTest.php
+++ b/tests/Unit/EncodingTest.php
@@ -415,6 +415,29 @@ class EncodingTest extends TestCase
         );
     }
 
+    public function test_it_can_encode_insert_rule_set_with_require_account()
+    {
+        $dispatchRules = new DispatchRulesParams(
+            userFuelBudget: new UserFuelBudgetParams(
+                amount: '1000000000',
+                resetPeriod: '500000',
+            ),
+        );
+
+        $data = $this->substrate->encode('InsertRuleSet', InsertRuleSetMutation::getEncodableParams(
+            tankId: '0x18353dcf7a6eb053b6f0c01774d1f8cfe0c15963780f6935c49a9fd4f50b893c',
+            ruleSetId: '1',
+            dispatchRules: $dispatchRules,
+            requireAccount: true,
+        ));
+
+        $callIndex = $this->codec->encoder()->getCallIndex('FuelTanks.insert_rule_set', true);
+        $this->assertEquals(
+            "0x{$callIndex}0018353dcf7a6eb053b6f0c01774d1f8cfe0c15963780f6935c49a9fd4f50b893c01000000040302286bee20a1070001",
+            $data
+        );
+    }
+
     public function test_it_can_encode_insert_or_update_rule_with_permitted_extrinsics()
     {
         $dispatchRules = new DispatchRulesParams(


### PR DESCRIPTION
### **PR Type**
Enhancement, Tests


___

### **Description**
- Added a new `requireAccount` argument to the `InsertRuleSetMutation` class, allowing users to specify if an account is required.
- Updated the `resolve` method and `getEncodableParams` to handle the new `requireAccount` parameter.
- Added feature and unit tests to ensure the correct functionality of the `requireAccount` parameter in both mutation and encoding processes.
- Updated GraphQL mutation to include the `requireAccount` variable.



___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>InsertRuleSetMutation.php</strong><dd><code>Add `requireAccount` argument to InsertRuleSetMutation</code>&nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/GraphQL/Mutations/InsertRuleSetMutation.php

<li>Added <code>requireAccount</code> argument to the mutation.<br> <li> Set default value for <code>requireAccount</code> to false.<br> <li> Updated <code>resolve</code> method to handle <code>requireAccount</code>.<br> <li> Modified <code>getEncodableParams</code> to include <code>requireAccount</code>.<br>


</details>


  </td>
  <td><a href="https://github.com/enjin/platform-fuel-tanks/pull/69/files#diff-d9d2d25b651fb6dc4e8b1c7b2b648a3d61cdbf755a4a91374b3b950ceb772ab7">+9/-2</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>InsertRuleSet.graphql</strong><dd><code>Update GraphQL mutation to include requireAccount</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

tests/Feature/GraphQL/Resources/InsertRuleSet.graphql

- Added `requireAccount` variable to GraphQL mutation.



</details>


  </td>
  <td><a href="https://github.com/enjin/platform-fuel-tanks/pull/69/files#diff-999707c2f65784e28e53a28c6a3edb1f33440c6b43793ae37138bf80d08d6697">+2/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    
</table></td></tr><tr><td><strong>Tests</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>InsertRuleSetTest.php</strong><dd><code>Add test for InsertRuleSet with requireAccount</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

tests/Feature/GraphQL/Mutations/InsertRuleSetTest.php

<li>Added a test for inserting rule set with <code>requireAccount</code>.<br> <li> Verified encoded data includes <code>requireAccount</code>.<br>


</details>


  </td>
  <td><a href="https://github.com/enjin/platform-fuel-tanks/pull/69/files#diff-cd21d2c8aee0237a65bcbb2448c0084606bbda0a31cf584f6cf2d4ac83a354fc">+22/-0</a>&nbsp; &nbsp; </td>

</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>EncodingTest.php</strong><dd><code>Add encoding test for InsertRuleSet with requireAccount</code>&nbsp; &nbsp; </dd></summary>
<hr>

tests/Unit/EncodingTest.php

<li>Added unit test for encoding InsertRuleSet with <code>requireAccount</code>.<br> <li> Verified encoded data correctness.<br>


</details>


  </td>
  <td><a href="https://github.com/enjin/platform-fuel-tanks/pull/69/files#diff-304632780535cba1fc76d5ae4d6cfca20af64a2f1fb2e4a782300d6035017d2e">+23/-0</a>&nbsp; &nbsp; </td>

</tr>                    
</table></td></tr></tr></tbody></table>

___

> 💡 **PR-Agent usage**: Comment `/help "your question"` on any pull request to receive relevant information