### PR TITLE
[PLA-1938] Fixes RuleSetInserted

### DIFF
--- a/src/Services/Processor/Substrate/Events/Implementations/FuelTanks/AccountAdded.php
+++ b/src/Services/Processor/Substrate/Events/Implementations/FuelTanks/AccountAdded.php
@@ -39,10 +39,9 @@ class AccountAdded extends FuelTankSubstrateEvent
     {
         Log::debug(
             sprintf(
-                'FuelTankAccount %s of FuelTank %s was created from transaction %s.',
+                'FuelTankAccount %s of FuelTank %s was created.',
                 $this->event->userId,
                 $this->event->tankId,
-                $transaction?->transaction_chain_hash ?? 'unknown',
             )
         );
     }

--- a/src/Services/Processor/Substrate/Events/Implementations/FuelTanks/FuelTankCreated.php
+++ b/src/Services/Processor/Substrate/Events/Implementations/FuelTanks/FuelTankCreated.php
@@ -95,9 +95,8 @@ class FuelTankCreated extends FuelTankSubstrateEvent
     {
         Log::debug(
             sprintf(
-                'FuelTank %s was created from transaction %s.',
+                'FuelTank %s was created.',
                 $this->event->tankId,
-                $transaction?->transaction_chain_hash ?? 'unknown',
             )
         );
     }

--- a/src/Services/Processor/Substrate/Events/Implementations/FuelTanks/RuleSetInserted.php
+++ b/src/Services/Processor/Substrate/Events/Implementations/FuelTanks/RuleSetInserted.php
@@ -26,7 +26,7 @@ class RuleSetInserted extends FuelTankSubstrateEvent
     {
         $extrinsic = $this->block->extrinsics[$this->event->extrinsicIndex];
         $params = $extrinsic->params;
-        $rules = Arr::get($params, 'rules', []);
+        $rules = Arr::get($params, 'rule_set.rules', []);
 
         // Fail if it doesn't find the fuel tank
         $fuelTank = $this->getFuelTank($this->event->tankId);

--- a/src/Services/Processor/Substrate/Events/Implementations/FuelTanks/RuleSetInserted.php
+++ b/src/Services/Processor/Substrate/Events/Implementations/FuelTanks/RuleSetInserted.php
@@ -57,9 +57,8 @@ class RuleSetInserted extends FuelTankSubstrateEvent
     {
         Log::debug(
             sprintf(
-                'RuleSetInserted at FuelTank %s from transaction %s.',
+                'RuleSetInserted at FuelTank %s.',
                 $this->event->tankId,
-                $transaction?->transaction_chain_hash ?? 'unknown',
             )
         );
     }

--- a/tests/Feature/GraphQL/Mutations/DispatchTest.php
+++ b/tests/Feature/GraphQL/Mutations/DispatchTest.php
@@ -225,7 +225,7 @@ class DispatchTest extends TestCaseGraphQL
         Arr::set($invalidData, 'dispatch.variables', 'Invalid');
         $response = $this->graphql($this->method, $invalidData, true);
         $this->assertStringContainsString(
-            'Variable "$dispatch" got invalid value "Invalid" at "dispatch.variables"; Expected type "Object".',
+            'Variable "$dispatch" got invalid value "Invalid" at "dispatch.variables"',
             $response['error']
         );
 


### PR DESCRIPTION
### **PR Type**
bug_fix


___

### **Description**
- Fixed a bug in `RuleSetInserted.php` by correcting the key used to access the `rules` from the `params` array.
- The key was changed from `rules` to `rule_set.rules` to ensure the correct data is retrieved.



___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>RuleSetInserted.php</strong><dd><code>Fix incorrect key for retrieving rules from parameters</code>&nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/Services/Processor/Substrate/Events/Implementations/FuelTanks/RuleSetInserted.php

<li>Modified the key used to retrieve <code>rules</code> from <code>params</code>.<br> <li> Changed from <code>rules</code> to <code>rule_set.rules</code>.<br>


</details>


  </td>
  <td><a href="https://github.com/enjin/platform-fuel-tanks/pull/72/files#diff-1477ea2b7c9e3184167ec8c7eea9ef1f5485a1fcd4c41e145717ba152628dea3">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

___

> 💡 **PR-Agent usage**: Comment `/help "your question"` on any pull request to receive relevant information