### PR TITLE
[PLA-2055] Fix CreateFuelTankMutation on no dispatchRule

### DIFF
--- a/src/GraphQL/Mutations/CreateFuelTankMutation.php
+++ b/src/GraphQL/Mutations/CreateFuelTankMutation.php
@@ -151,7 +151,7 @@ class CreateFuelTankMutation extends Mutation implements PlatformBlockchainTrans
             'descriptor' => [
                 'name' => HexConverter::stringToHexPrefixed($name),
                 'userAccountManagement' => $userAccountManagement?->toEncodable(),
-                'coveragePolicy' => $coveragePolicy->value,
+                'coveragePolicy' => $coveragePolicy?->value ?? CoveragePolicy::FEES->value,
                 'ruleSets' =>  [
                     [
                         'rules' => $ruleSets->flatMap(fn ($ruleSet) => $ruleSet->toEncodable())->all(),

--- a/src/GraphQL/Mutations/CreateFuelTankMutation.php
+++ b/src/GraphQL/Mutations/CreateFuelTankMutation.php
@@ -128,7 +128,7 @@ class CreateFuelTankMutation extends Mutation implements PlatformBlockchainTrans
 
     public static function addPermittedExtrinsics(string $encodedData, array $dispatchRules): string
     {
-        if ($dispatchRules[0]->permittedExtrinsics === null) {
+        if (empty($dispatchRules) || $dispatchRules[0]->permittedExtrinsics === null) {
             return $encodedData;
         }
 

--- a/tests/Feature/GraphQL/Mutations/CreateFuelTankTest.php
+++ b/tests/Feature/GraphQL/Mutations/CreateFuelTankTest.php
@@ -35,6 +35,21 @@ class CreateFuelTankTest extends TestCaseGraphQL
         );
     }
 
+    public function test_it_can_create_fuel_tank_only_with_required_args(): void
+    {
+        $data = [
+            'name' => fake()->text(32),
+        ];
+
+        $response = $this->graphql($this->method, $data);
+        $expectedData = TransactionSerializer::encode($this->method, CreateFuelTankMutation::getEncodableParams(...$data));
+
+        $this->assertEquals(
+            $expectedData,
+            $response['encodedData'],
+        );
+    }
+
     public function test_it_can_create_fuel_tank_with_zero_values(): void
     {
         $response = $this->graphql($this->method, $data = $this->generateData(true, 0));


### PR DESCRIPTION
### **PR Type**
Bug fix


___

### **Description**
- Fixed a potential error in the `addPermittedExtrinsics` method of `CreateFuelTankMutation` by adding a check to ensure `dispatchRules` is not empty before accessing its first element.
- Improved error handling to prevent null reference issues.



___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>CreateFuelTankMutation.php</strong><dd><code>Fix potential error when `dispatchRules` is empty</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/GraphQL/Mutations/CreateFuelTankMutation.php

<li>Added a check to ensure <code>dispatchRules</code> is not empty before accessing <br>its first element.<br> <li> Prevented potential errors when <code>dispatchRules</code> is empty.<br>


</details>


  </td>
  <td><a href="https://github.com/enjin/platform-fuel-tanks/pull/75/files#diff-db0576a64d2ce59dfac4687e0bb972f3cafca8f05b45531ec30854a04e21fc66">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

___

> 💡 **PR-Agent usage**: Comment `/help "your question"` on any pull request to receive relevant information