### PR TITLE
[PLA-2055] Adds requireAccount to CreateFuelTank & validation rule to userFuelBudget

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -25,21 +25,20 @@
         "enjin/platform-core": "*",
         "phrity/websocket": "^1.0",
         "rebing/graphql-laravel": "^9.0",
-        "rector/rector": "^1.0",
         "spatie/laravel-package-tools": "^1.0",
         "spatie/laravel-ray": "^1.0"
     },
     "require-dev": {
-        "dms/phpunit-arraysubset-asserts": "dev-master",
         "laravel/pint": "^1.0",
         "nunomaduro/collision": "^8.0",
-        "larastan/larastan": "^2.0",
+        "larastan/larastan": "^3.0",
         "orchestra/testbench": "^9.0",
         "phpstan/extension-installer": "^1.0",
-        "phpstan/phpstan-deprecation-rules": "^1.0",
-        "phpstan/phpstan-phpunit": "^1.0",
-        "phpunit/php-code-coverage": "^10.0",
-        "phpunit/phpunit": "^10.0",
+        "phpstan/phpstan-deprecation-rules": "^2.0",
+        "phpstan/phpstan-phpunit": "^2.0",
+        "phpunit/php-code-coverage": "^11.0",
+        "phpunit/phpunit": "^11.0",
+        "rector/rector": "2.0.0-rc3",
         "roave/security-advisories": "dev-latest"
     },
     "autoload": {

--- a/src/GraphQL/Mutations/CreateFuelTankMutation.php
+++ b/src/GraphQL/Mutations/CreateFuelTankMutation.php
@@ -79,6 +79,11 @@ class CreateFuelTankMutation extends Mutation implements PlatformBlockchainTrans
                 'type' => GraphQL::type('[DispatchRuleInputType!]'),
                 'description' => __('enjin-platform-fuel-tanks::input_type.dispatch_rule.description'),
             ],
+            'requireAccount' => [
+                'type' => GraphQL::type('Boolean'),
+                'description' => __('enjin-platform-fuel-tanks::mutation.insert_rule_set.args.requireAccount'),
+                'defaultValue' => false,
+            ],
             ...$this->getSigningAccountField(),
             ...$this->getIdempotencyField(),
             ...$this->getSimulateField(),
@@ -114,6 +119,7 @@ class CreateFuelTankMutation extends Mutation implements PlatformBlockchainTrans
             name: $args['name'],
             userAccountManagement: $blockchainService->getUserAccountManagementParams($args),
             dispatchRules: $dispatchRules,
+            requireAccount: $args['requireAccount'],
             coveragePolicy: $args['coveragePolicy'] ?? CoveragePolicy::FEES,
             accountRules: $blockchainService->getAccountRulesParams($args)
         ));
@@ -146,6 +152,7 @@ class CreateFuelTankMutation extends Mutation implements PlatformBlockchainTrans
         $ruleSets = collect(Arr::get($params, 'dispatchRules', []));
         $coveragePolicy = is_string($coverage = Arr::get($params, 'coveragePolicy')) ? CoveragePolicy::getEnumCase($coverage) : $coverage;
         $accountRules = Arr::get($params, 'accountRules', new AccountRulesParams());
+        $requireAccount = Arr::get($params, 'requireAccount', false);
 
         return [
             'descriptor' => [
@@ -155,7 +162,7 @@ class CreateFuelTankMutation extends Mutation implements PlatformBlockchainTrans
                 'ruleSets' =>  [
                     [
                         'rules' => $ruleSets->flatMap(fn ($ruleSet) => $ruleSet->toEncodable())->all(),
-                        'requireAccount' => false,
+                        'requireAccount' => $requireAccount,
                     ],
                 ],
                 'accountRules' => $accountRules?->toEncodable() ?? [],

--- a/src/GraphQL/Traits/HasFuelTankValidationRules.php
+++ b/src/GraphQL/Traits/HasFuelTankValidationRules.php
@@ -163,6 +163,7 @@ trait HasFuelTankValidationRules
             ...$this->commonRulesExist("{$attributePrefix}dispatchRules{$array}.tankFuelBudget"),
             "{$attributePrefix}dispatchRules{$array}.whitelistedPallets.*" => ['bail', 'distinct', 'max:255', 'filled', new ValidHex()],
             "{$attributePrefix}dispatchRules{$array}.whitelistedPallets" => ['nullable', 'array', 'min:1'],
+            "{$attributePrefix}dispatchRules{$array}.userFuelBudget" => ['prohibited_unless:requireAccount,true'],
         ];
     }
 
@@ -194,6 +195,7 @@ trait HasFuelTankValidationRules
             ...$this->commonRules("{$attributePrefix}dispatchRules{$array}.tankFuelBudget"),
             "{$attributePrefix}dispatchRules{$array}.whitelistedPallets.*" => ['bail', 'distinct', 'max:255', 'filled', new ValidHex()],
             "{$attributePrefix}dispatchRules{$array}.whitelistedPallets" => ['nullable', 'array', 'min:1'],
+            "{$attributePrefix}dispatchRules{$array}.userFuelBudget" => ["prohibited_unless:{$attributePrefix}requireAccount,true"],
         ];
     }
 }

--- a/tests/Feature/GraphQL/Mutations/AddAccountTest.php
+++ b/tests/Feature/GraphQL/Mutations/AddAccountTest.php
@@ -64,7 +64,7 @@ class AddAccountTest extends TestCaseGraphQL
             ['tankId' => $publicKey, 'userId' => $publicKey],
             true
         );
-        $this->assertArraySubset(
+        $this->assertArrayContainsArray(
             ['tankId' => ['The selected tankId is invalid.']],
             $response['error']
         );
@@ -74,7 +74,7 @@ class AddAccountTest extends TestCaseGraphQL
             ['tankId' => Str::random(300), 'userId' => $publicKey],
             true
         );
-        $this->assertArraySubset(
+        $this->assertArrayContainsArray(
             ['tankId' => ['The tank id field must not be greater than 255 characters.']],
             $response['error']
         );
@@ -84,7 +84,7 @@ class AddAccountTest extends TestCaseGraphQL
             ['tankId' => 'Invalid', 'userId' => $publicKey],
             true
         );
-        $this->assertArraySubset(
+        $this->assertArrayContainsArray(
             ['tankId' => ['The tank id is not a valid substrate address.']],
             $response['error']
         );
@@ -105,7 +105,7 @@ class AddAccountTest extends TestCaseGraphQL
             ['tankId' => $tank->public_key, 'userId' => $publicKey],
             true
         );
-        $this->assertArraySubset(
+        $this->assertArrayContainsArray(
             ['tankId' => ['The tank id provided is not owned by you.']],
             $response['error']
         );
@@ -118,7 +118,7 @@ class AddAccountTest extends TestCaseGraphQL
             ['tankId' => $this->tank->public_key, 'userId' => 'Invalid'],
             true
         );
-        $this->assertArraySubset(
+        $this->assertArrayContainsArray(
             ['userId' => ['The user id is not a valid substrate address.']],
             $response['error']
         );
@@ -138,7 +138,7 @@ class AddAccountTest extends TestCaseGraphQL
             ['tankId' => $this->tank->public_key, 'userId' => Str::random(300)],
             true
         );
-        $this->assertArraySubset(
+        $this->assertArrayContainsArray(
             ['userId' => ['The user id field must not be greater than 255 characters.']],
             $response['error']
         );
@@ -153,7 +153,7 @@ class AddAccountTest extends TestCaseGraphQL
             ['tankId' => $this->tank->public_key, 'userId' => $publicKey],
             true
         );
-        $this->assertArraySubset(
+        $this->assertArrayContainsArray(
             ['userId' => ['The user id contains an account that already exists in the fuel tank.']],
             $response['error']
         );

--- a/tests/Feature/GraphQL/Mutations/BatchAddAccountTest.php
+++ b/tests/Feature/GraphQL/Mutations/BatchAddAccountTest.php
@@ -65,7 +65,7 @@ class BatchAddAccountTest extends TestCaseGraphQL
             ['tankId' => $pubicKey, 'userIds' => [$pubicKey]],
             true
         );
-        $this->assertArraySubset(
+        $this->assertArrayContainsArray(
             ['tankId' => ['The selected tankId is invalid.']],
             $response['error']
         );
@@ -75,7 +75,7 @@ class BatchAddAccountTest extends TestCaseGraphQL
             ['tankId' => Str::random(300), 'userIds' => [$pubicKey]],
             true
         );
-        $this->assertArraySubset(
+        $this->assertArrayContainsArray(
             ['tankId' => ['The tank id field must not be greater than 255 characters.']],
             $response['error']
         );
@@ -85,7 +85,7 @@ class BatchAddAccountTest extends TestCaseGraphQL
             ['tankId' => 'Invalid', 'userIds' => [$pubicKey]],
             true
         );
-        $this->assertArraySubset(
+        $this->assertArrayContainsArray(
             ['tankId' => ['The tank id is not a valid substrate address.']],
             $response['error']
         );
@@ -106,7 +106,7 @@ class BatchAddAccountTest extends TestCaseGraphQL
             ['tankId' => $tank->public_key, 'userIds' => [$pubicKey]],
             true
         );
-        $this->assertArraySubset(
+        $this->assertArrayContainsArray(
             ['tankId' => ['The tank id provided is not owned by you.']],
             $response['error']
         );
@@ -119,7 +119,7 @@ class BatchAddAccountTest extends TestCaseGraphQL
             ['tankId' => $this->tank->public_key, 'userIds' => 'Invalid'],
             true
         );
-        $this->assertArraySubset(
+        $this->assertArrayContainsArray(
             ['userIds.0' => ['The userIds.0 is not a valid substrate address.']],
             $response['error']
         );
@@ -139,7 +139,7 @@ class BatchAddAccountTest extends TestCaseGraphQL
             ['tankId' => $this->tank->public_key, 'userIds' => ''],
             true
         );
-        $this->assertArraySubset(
+        $this->assertArrayContainsArray(
             ['userIds.0' => ['The userIds.0 field must have a value.']],
             $response['error']
         );
@@ -149,7 +149,7 @@ class BatchAddAccountTest extends TestCaseGraphQL
             ['tankId' => $this->tank->public_key, 'userIds' => [Str::random(300)]],
             true
         );
-        $this->assertArraySubset(
+        $this->assertArrayContainsArray(
             ['userIds.0' => ['The userIds.0 field must not be greater than 255 characters.']],
             $response['error']
         );
@@ -160,7 +160,7 @@ class BatchAddAccountTest extends TestCaseGraphQL
             ['tankId' => $this->tank->public_key, 'userIds' => [$publicKey, $publicKey]],
             true
         );
-        $this->assertArraySubset(
+        $this->assertArrayContainsArray(
             [
                 'userIds.0' => ['The userIds.0 field has a duplicate value.'],
                 'userIds.1' => ['The userIds.1 field has a duplicate value.'],
@@ -178,7 +178,7 @@ class BatchAddAccountTest extends TestCaseGraphQL
             ['tankId' => $this->tank->public_key, 'userIds' => [$publicKey]],
             true
         );
-        $this->assertArraySubset(
+        $this->assertArrayContainsArray(
             ['userIds' => ['The user ids contains an account that already exists in the fuel tank.']],
             $response['error']
         );
@@ -191,7 +191,7 @@ class BatchAddAccountTest extends TestCaseGraphQL
                 'userIds' => Collection::range(1, 101)->map(fn ($row) => $provider->public_key())->toArray()],
             true
         );
-        $this->assertArraySubset(
+        $this->assertArrayContainsArray(
             ['userIds' => ['The user ids field must not have more than 100 items.']],
             $response['error']
         );

--- a/tests/Feature/GraphQL/Mutations/BatchRemoveAccountTest.php
+++ b/tests/Feature/GraphQL/Mutations/BatchRemoveAccountTest.php
@@ -75,7 +75,7 @@ class BatchRemoveAccountTest extends TestCaseGraphQL
             ['tankId' => $pubicKey, 'userIds' => [$this->account]],
             true
         );
-        $this->assertArraySubset(
+        $this->assertArrayContainsArray(
             ['tankId' => ['The selected tankId is invalid.']],
             $response['error']
         );
@@ -85,7 +85,7 @@ class BatchRemoveAccountTest extends TestCaseGraphQL
             ['tankId' => Str::random(300), 'userIds' => [$this->account]],
             true
         );
-        $this->assertArraySubset(
+        $this->assertArrayContainsArray(
             ['tankId' => ['The tank id field must not be greater than 255 characters.']],
             $response['error']
         );
@@ -95,7 +95,7 @@ class BatchRemoveAccountTest extends TestCaseGraphQL
             ['tankId' => 'Invalid', 'userIds' => [$this->account]],
             true
         );
-        $this->assertArraySubset(
+        $this->assertArrayContainsArray(
             ['tankId' => ['The tank id is not a valid substrate address.']],
             $response['error']
         );
@@ -116,7 +116,7 @@ class BatchRemoveAccountTest extends TestCaseGraphQL
             ['tankId' => $tank->public_key, 'userIds' => [$this->account]],
             true
         );
-        $this->assertArraySubset(
+        $this->assertArrayContainsArray(
             ['tankId' => ['The tank id provided is not owned by you.']],
             $response['error']
         );
@@ -129,7 +129,8 @@ class BatchRemoveAccountTest extends TestCaseGraphQL
             ['tankId' => $this->tank->public_key, 'userIds' => 'Invalid'],
             true
         );
-        $this->assertArraySubset(
+
+        $this->assertArrayContainsArray(
             ['userIds.0' => ['The userIds.0 is not a valid substrate address.']],
             $response['error']
         );
@@ -149,7 +150,7 @@ class BatchRemoveAccountTest extends TestCaseGraphQL
             ['tankId' => $this->tank->public_key, 'userIds' => [Str::random(300)]],
             true
         );
-        $this->assertArraySubset(
+        $this->assertArrayContainsArray(
             ['userIds.0' => ['The userIds.0 field must not be greater than 255 characters.']],
             $response['error']
         );
@@ -160,7 +161,7 @@ class BatchRemoveAccountTest extends TestCaseGraphQL
             ['tankId' => $this->tank->public_key, 'userIds' => [$pubicKey, $pubicKey]],
             true
         );
-        $this->assertArraySubset(
+        $this->assertArrayContainsArray(
             [
                 'userIds.0' => ['The userIds.0 field has a duplicate value.'],
                 'userIds.1' => ['The userIds.1 field has a duplicate value.'],
@@ -175,7 +176,7 @@ class BatchRemoveAccountTest extends TestCaseGraphQL
             ['tankId' => $this->tank->public_key, 'userIds' => [$this->account]],
             true
         );
-        $this->assertArraySubset(
+        $this->assertArrayContainsArray(
             ['userIds' => ["The user ids contains an account that doesn't exist in the fuel tank."]],
             $response['error']
         );
@@ -188,7 +189,7 @@ class BatchRemoveAccountTest extends TestCaseGraphQL
                 'userIds' => Collection::range(1, 101)->map(fn ($row) => $provider->public_key())->toArray()],
             true
         );
-        $this->assertArraySubset(
+        $this->assertArrayContainsArray(
             ['userIds' => ['The user ids field must not have more than 100 items.']],
             $response['error']
         );

--- a/tests/Feature/GraphQL/Mutations/CreateFuelTankTest.php
+++ b/tests/Feature/GraphQL/Mutations/CreateFuelTankTest.php
@@ -89,6 +89,7 @@ class CreateFuelTankTest extends TestCaseGraphQL
                 'tankFuelBudget' => ['amount' => $value ?? fake()->numberBetween(1, 1000), 'resetPeriod' => fake()->numberBetween(1, 1000)],
                 'permittedExtrinsics' => ['CreateCollection', 'ApproveCollection', 'SimpleTransferToken', 'OperatorTransferToken'],
             ]],
+            'requireAccount' => true,
             'skipValidation' => true,
         ]);
 
@@ -102,6 +103,23 @@ class CreateFuelTankTest extends TestCaseGraphQL
             $expectedData,
             $response['encodedData'],
         );
+    }
+
+    public function test_it_will_fail_with_require_account_false_and_user_fuel_budget(): void
+    {
+        $response = $this->graphql($this->method, [
+            'name' => fake()->text(32),
+            'account' => resolve(SubstrateProvider::class)->public_key(),
+            'dispatchRules' => [[
+                'userFuelBudget' => ['amount' => $value ?? fake()->numberBetween(1, 1000), 'resetPeriod' => fake()->numberBetween(1, 1000)],
+            ]],
+            'requireAccount' => false,
+            'skipValidation' => true,
+        ], true);
+
+        $this->assertArrayContainsArray([
+            'dispatchRules.0.userFuelBudget' => ['The dispatchRules.0.userFuelBudget field is prohibited unless require account is in true.'],
+        ], $response['error']);
     }
 
     public function test_it_will_fail_with_invalid_parameter_name(): void

--- a/tests/Feature/GraphQL/Mutations/CreateFuelTankTest.php
+++ b/tests/Feature/GraphQL/Mutations/CreateFuelTankTest.php
@@ -114,7 +114,7 @@ class CreateFuelTankTest extends TestCaseGraphQL
         ]);
 
         $response = $this->graphql($this->method, $data, true);
-        $this->assertArraySubset(
+        $this->assertArrayContainsArray(
             ['name' => ['The name has already been taken.']],
             $response['error']
         );
@@ -124,7 +124,7 @@ class CreateFuelTankTest extends TestCaseGraphQL
             array_merge($data, ['name' => "This is a very long name that will fail because it's too long"]),
             true
         );
-        $this->assertArraySubset(
+        $this->assertArrayContainsArray(
             ['name' => ['The name field must not be greater than 32 characters.']],
             $response['error']
         );
@@ -141,7 +141,7 @@ class CreateFuelTankTest extends TestCaseGraphQL
             array_merge($data, ['name' => '']),
             true
         );
-        $this->assertArraySubset(
+        $this->assertArrayContainsArray(
             ['name' => ['The name field must have a value.']],
             $response['error']
         );
@@ -166,7 +166,7 @@ class CreateFuelTankTest extends TestCaseGraphQL
             array_merge($data, ['accountRules' => ['whitelistedCallers' => ['Invalid']]]),
             true
         );
-        $this->assertArraySubset(
+        $this->assertArrayContainsArray(
             ['accountRules.whitelistedCallers.0' => ['The accountRules.whitelistedCallers.0 is not a valid substrate address.']],
             $response['error']
         );
@@ -176,7 +176,7 @@ class CreateFuelTankTest extends TestCaseGraphQL
             array_merge($data, ['accountRules' => ['whitelistedCallers' => [$data['account'], $data['account']]]]),
             true
         );
-        $this->assertArraySubset(
+        $this->assertArrayContainsArray(
             ['accountRules.whitelistedCallers.0' => ['The accountRules.whitelistedCallers.0 field has a duplicate value.']],
             $response['error']
         );
@@ -186,7 +186,7 @@ class CreateFuelTankTest extends TestCaseGraphQL
             array_merge($data, ['accountRules' => ['whitelistedCallers' => [Str::random(300)]]]),
             true
         );
-        $this->assertArraySubset(
+        $this->assertArrayContainsArray(
             ['accountRules.whitelistedCallers.0' => ['The accountRules.whitelistedCallers.0 field must not be greater than 255 characters.']],
             $response['error']
         );
@@ -196,7 +196,7 @@ class CreateFuelTankTest extends TestCaseGraphQL
             array_merge($data, ['accountRules' => ['whitelistedCallers' => []]]),
             true
         );
-        $this->assertArraySubset(
+        $this->assertArrayContainsArray(
             ['accountRules.whitelistedCallers' => ['The account rules.whitelisted callers field must have at least 1 items.']],
             $response['error']
         );
@@ -213,7 +213,7 @@ class CreateFuelTankTest extends TestCaseGraphQL
             array_merge($data, ['accountRules' => ['whitelistedCallers' => '']]),
             true
         );
-        $this->assertArraySubset(
+        $this->assertArrayContainsArray(
             ['accountRules.whitelistedCallers.0' => ['The accountRules.whitelistedCallers.0 field must have a value.']],
             $response['error']
         );
@@ -227,7 +227,7 @@ class CreateFuelTankTest extends TestCaseGraphQL
             array_merge($data, ['accountRules' => ['requireToken' => ['collectionId' => 1, 'tokenId' => ['integer' => 1]]]]),
             true
         );
-        $this->assertArraySubset(
+        $this->assertArrayContainsArray(
             [
                 'accountRules.requireToken.collectionId' => ['The selected account rules.require token.collection id is invalid.'],
             ],
@@ -259,7 +259,7 @@ class CreateFuelTankTest extends TestCaseGraphQL
             array_merge($data, ['accountRules' => ['requireToken' => ['collectionId' => Hex::MAX_UINT256 + 1, 'tokenId' => ['integer' => Hex::MAX_UINT256 + 1]]]]),
             true
         );
-        $this->assertArraySubset(
+        $this->assertArrayContainsArray(
             [
                 0 => [
                     'message' => 'Variable "$accountRules" got invalid value 1.1579208923732E+77 at "accountRules.requireToken.collectionId"; Cannot represent following value as uint256: 1.1579208923732E+77',
@@ -280,7 +280,7 @@ class CreateFuelTankTest extends TestCaseGraphQL
             array_merge($data, ['dispatchRules' => [['whitelistedCallers' => ['Invalid']]]]),
             true
         );
-        $this->assertArraySubset(
+        $this->assertArrayContainsArray(
             ['dispatchRules.0.whitelistedCallers.0' => ['The dispatchRules.0.whitelistedCallers.0 is not a valid substrate address.']],
             $response['error']
         );
@@ -290,7 +290,7 @@ class CreateFuelTankTest extends TestCaseGraphQL
             array_merge($data, ['dispatchRules' => [['whitelistedCallers' => [$data['account'], $data['account']]]]]),
             true
         );
-        $this->assertArraySubset(
+        $this->assertArrayContainsArray(
             ['dispatchRules.0.whitelistedCallers.0' => ['The dispatchRules.0.whitelistedCallers.0 field has a duplicate value.']],
             $response['error']
         );
@@ -300,7 +300,7 @@ class CreateFuelTankTest extends TestCaseGraphQL
             array_merge($data, ['dispatchRules' => [['whitelistedCallers' => [Str::random(300)]]]]),
             true
         );
-        $this->assertArraySubset(
+        $this->assertArrayContainsArray(
             ['dispatchRules.0.whitelistedCallers.0' => ['The dispatchRules.0.whitelistedCallers.0 field must not be greater than 255 characters.']],
             $response['error']
         );
@@ -310,7 +310,7 @@ class CreateFuelTankTest extends TestCaseGraphQL
             array_merge($data, ['dispatchRules' => [['whitelistedCallers' => []]]]),
             true
         );
-        $this->assertArraySubset(
+        $this->assertArrayContainsArray(
             ['dispatchRules.0.whitelistedCallers' => ['The dispatchRules.0.whitelistedCallers field must have at least 1 items.']],
             $response['error']
         );
@@ -327,7 +327,7 @@ class CreateFuelTankTest extends TestCaseGraphQL
             array_merge($data, ['dispatchRules' => [['whitelistedCallers' => '']]]),
             true
         );
-        $this->assertArraySubset(
+        $this->assertArrayContainsArray(
             ['dispatchRules.0.whitelistedCallers.0' => ['The dispatchRules.0.whitelistedCallers.0 field must have a value.']],
             $response['error']
         );
@@ -341,7 +341,7 @@ class CreateFuelTankTest extends TestCaseGraphQL
             array_merge($data, ['dispatchRules' => [['requireToken' => ['collectionId' => 1, 'tokenId' => ['integer' => 1]]]]]),
             true
         );
-        $this->assertArraySubset(
+        $this->assertArrayContainsArray(
             ['dispatchRules.0.requireToken.collectionId' => ['The selected dispatchRules.0.requireToken.collectionId is invalid.']],
             $response['error']
         );
@@ -371,7 +371,7 @@ class CreateFuelTankTest extends TestCaseGraphQL
             array_merge($data, ['dispatchRules' => [['requireToken' => ['collectionId' => Hex::MAX_UINT256 + 1, 'tokenId' => ['integer' => Hex::MAX_UINT256 + 1]]]]]),
             true
         );
-        $this->assertArraySubset(
+        $this->assertArrayContainsArray(
             [
                 0 => [
                     'message' => 'Variable "$dispatchRules" got invalid value 1.1579208923732E+77 at "dispatchRules[0].requireToken.collectionId"; Cannot represent following value as uint256: 1.1579208923732E+77',
@@ -402,7 +402,7 @@ class CreateFuelTankTest extends TestCaseGraphQL
             array_merge($data, ['dispatchRules' => [['whitelistedCollections' => [1, 1]]]]),
             true
         );
-        $this->assertArraySubset(
+        $this->assertArrayContainsArray(
             ['dispatchRules.0.whitelistedCollections.0' => ['The dispatchRules.0.whitelistedCollections.0 field has a duplicate value.']],
             $response['error']
         );
@@ -412,7 +412,7 @@ class CreateFuelTankTest extends TestCaseGraphQL
             array_merge($data, ['dispatchRules' => [['whitelistedCollections' => [5000]]]]),
             true
         );
-        $this->assertArraySubset(
+        $this->assertArrayContainsArray(
             ['dispatchRules.0.whitelistedCollections.0' => ['The selected dispatchRules.0.whitelistedCollections.0 is invalid.']],
             $response['error']
         );
@@ -422,7 +422,7 @@ class CreateFuelTankTest extends TestCaseGraphQL
             array_merge($data, ['dispatchRules' => [['whitelistedCollections' => []]]]),
             true
         );
-        $this->assertArraySubset(
+        $this->assertArrayContainsArray(
             ['dispatchRules.0.whitelistedCollections' => ['The dispatchRules.0.whitelistedCollections field must have at least 1 items.']],
             $response['error']
         );
@@ -477,7 +477,7 @@ class CreateFuelTankTest extends TestCaseGraphQL
             array_merge($data, ['dispatchRules' => [['userFuelBudget' => ['amount' => 'Invalid', 'resetPeriod' => 'Invalid']]]]),
             true
         );
-        $this->assertArraySubset(
+        $this->assertArrayContainsArray(
             [
                 0 => [
                     'message' => 'Variable "$dispatchRules" got invalid value "Invalid" at "dispatchRules[0].userFuelBudget.amount"; Cannot represent following value as uint256: "Invalid"',
@@ -494,7 +494,7 @@ class CreateFuelTankTest extends TestCaseGraphQL
             array_merge($data, ['dispatchRules' => [['userFuelBudget' => ['amount' => Hex::MAX_UINT256 + 1, 'resetPeriod' => Hex::MAX_UINT256 + 1]]]]),
             true
         );
-        $this->assertArraySubset(
+        $this->assertArrayContainsArray(
             [
                 0 => [
                     'message' => 'Variable "$dispatchRules" got invalid value 1.1579208923732E+77 at "dispatchRules[0].userFuelBudget.amount"; Cannot represent following value as uint256: 1.1579208923732E+77',
@@ -515,7 +515,7 @@ class CreateFuelTankTest extends TestCaseGraphQL
             array_merge($data, ['dispatchRules' => [['tankFuelBudget' => ['amount' => 'Invalid', 'resetPeriod' => 'Invalid']]]]),
             true
         );
-        $this->assertArraySubset(
+        $this->assertArrayContainsArray(
             [
                 ['message' => 'Variable "$dispatchRules" got invalid value "Invalid" at "dispatchRules[0].tankFuelBudget.amount"; Cannot represent following value as uint256: "Invalid"'],
                 ['message' => 'Variable "$dispatchRules" got invalid value "Invalid" at "dispatchRules[0].tankFuelBudget.resetPeriod"; Cannot represent following value as uint256: "Invalid"'],
@@ -528,7 +528,7 @@ class CreateFuelTankTest extends TestCaseGraphQL
             array_merge($data, ['dispatchRules' => [['tankFuelBudget' => ['amount' => Hex::MAX_UINT256 + 1, 'resetPeriod' => Hex::MAX_UINT256 + 1]]]]),
             true
         );
-        $this->assertArraySubset(
+        $this->assertArrayContainsArray(
             [
                 0 => [
                     'message' => 'Variable "$dispatchRules" got invalid value 1.1579208923732E+77 at "dispatchRules[0].tankFuelBudget.amount"; Cannot represent following value as uint256: 1.1579208923732E+77',

--- a/tests/Feature/GraphQL/Mutations/DestroyFuelTankTest.php
+++ b/tests/Feature/GraphQL/Mutations/DestroyFuelTankTest.php
@@ -43,19 +43,19 @@ class DestroyFuelTankTest extends TestCaseGraphQL
     {
         $pubicKey = resolve(SubstrateProvider::class)->public_key();
         $response = $this->graphql($this->method, ['tankId' => $pubicKey], true);
-        $this->assertArraySubset(
+        $this->assertArrayContainsArray(
             ['tankId' => ['The selected tankId is invalid.']],
             $response['error']
         );
 
         $response = $this->graphql($this->method, ['tankId' => Str::random(300)], true);
-        $this->assertArraySubset(
+        $this->assertArrayContainsArray(
             ['tankId' => ['The tank id field must not be greater than 255 characters.']],
             $response['error']
         );
 
         $response = $this->graphql($this->method, ['tankId' => 'Invalid'], true);
-        $this->assertArraySubset(
+        $this->assertArrayContainsArray(
             ['tankId' => ['The tank id is not a valid substrate address.']],
             $response['error']
         );
@@ -72,7 +72,7 @@ class DestroyFuelTankTest extends TestCaseGraphQL
         );
         $tank->forceFill(['owner_wallet_id' => $wallet->id])->save();
         $response = $this->graphql($this->method, ['tankId' => $tank->public_key], true);
-        $this->assertArraySubset(
+        $this->assertArrayContainsArray(
             ['tankId' => ['The tank id provided is not owned by you.']],
             $response['error']
         );

--- a/tests/Feature/GraphQL/Mutations/DispatchTest.php
+++ b/tests/Feature/GraphQL/Mutations/DispatchTest.php
@@ -89,7 +89,7 @@ class DispatchTest extends TestCaseGraphQL
             array_merge($data, ['tankId' => $pubicKey]),
             true
         );
-        $this->assertArraySubset(
+        $this->assertArrayContainsArray(
             ['tankId' => ['The selected tankId is invalid.']],
             $response['error']
         );
@@ -99,7 +99,7 @@ class DispatchTest extends TestCaseGraphQL
             array_merge($data, ['tankId' => Str::random(300)]),
             true
         );
-        $this->assertArraySubset(
+        $this->assertArrayContainsArray(
             ['tankId' => ['The tank id field must not be greater than 255 characters.']],
             $response['error']
         );
@@ -109,7 +109,7 @@ class DispatchTest extends TestCaseGraphQL
             array_merge($data, ['tankId' => 'Invalid']),
             true
         );
-        $this->assertArraySubset(
+        $this->assertArrayContainsArray(
             ['tankId' => ['The tank id is not a valid substrate address.']],
             $response['error']
         );
@@ -156,7 +156,7 @@ class DispatchTest extends TestCaseGraphQL
             true
         );
 
-        $this->assertArraySubset(
+        $this->assertArrayContainsArray(
             ['ruleSetId' => ['The rule set id is too large, the maximum value it can be is 4294967295.']],
             $response['error']
         );
@@ -165,7 +165,7 @@ class DispatchTest extends TestCaseGraphQL
             array_merge($data, ['ruleSetId' => fake()->numberBetween(5000, 10000)]),
             true
         );
-        $this->assertArraySubset(
+        $this->assertArrayContainsArray(
             ['ruleSetId' => ["The rule set ID doesn't exist."]],
             $response['error']
         );
@@ -194,14 +194,14 @@ class DispatchTest extends TestCaseGraphQL
         $invalidData = $data;
         Arr::set($invalidData, 'dispatch.query', str_replace('id', '', static::$queries['AddAccount']));
         $response = $this->graphql($this->method, $invalidData, true);
-        $this->assertArraySubset(
+        $this->assertArrayContainsArray(
             ['dispatch.query' => ['The id and encodedData attribute must be queried from the result.']],
             $response['error']
         );
 
         Arr::set($invalidData, 'dispatch.query', str_replace('encodedData', '', static::$queries['AddAccount']));
         $response = $this->graphql($this->method, $invalidData, true);
-        $this->assertArraySubset(
+        $this->assertArrayContainsArray(
             ['dispatch.query' => ['The id and encodedData attribute must be queried from the result.']],
             $response['error']
         );

--- a/tests/Feature/GraphQL/Mutations/InsertRuleSetTest.php
+++ b/tests/Feature/GraphQL/Mutations/InsertRuleSetTest.php
@@ -114,7 +114,7 @@ class InsertRuleSetTest extends TestCaseGraphQL
             array_merge($data, ['tankId' => $pubicKey]),
             true
         );
-        $this->assertArraySubset(
+        $this->assertArrayContainsArray(
             ['tankId' => ['The selected tankId is invalid.']],
             $response['error']
         );
@@ -124,7 +124,7 @@ class InsertRuleSetTest extends TestCaseGraphQL
             array_merge($data, ['tankId' => Str::random(300)]),
             true
         );
-        $this->assertArraySubset(
+        $this->assertArrayContainsArray(
             ['tankId' => ['The tank id field must not be greater than 255 characters.']],
             $response['error']
         );
@@ -134,7 +134,7 @@ class InsertRuleSetTest extends TestCaseGraphQL
             array_merge($data, ['tankId' => 'Invalid']),
             true
         );
-        $this->assertArraySubset(
+        $this->assertArrayContainsArray(
             ['tankId' => ['The tank id is not a valid substrate address.']],
             $response['error']
         );
@@ -155,7 +155,7 @@ class InsertRuleSetTest extends TestCaseGraphQL
             array_merge($data, ['tankId' => $tank->public_key]),
             true
         );
-        $this->assertArraySubset(
+        $this->assertArrayContainsArray(
             ['tankId' => ['The tank id provided is not owned by you.']],
             $response['error']
         );
@@ -203,7 +203,7 @@ class InsertRuleSetTest extends TestCaseGraphQL
             array_merge($data, ['dispatchRules' => ['whitelistedCallers' => ['Invalid']]]),
             true
         );
-        $this->assertArraySubset(
+        $this->assertArrayContainsArray(
             ['dispatchRules.whitelistedCallers.0' => ['The dispatchRules.whitelistedCallers.0 is not a valid substrate address.']],
             $response['error']
         );
@@ -213,7 +213,7 @@ class InsertRuleSetTest extends TestCaseGraphQL
             array_merge($data, ['dispatchRules' => ['whitelistedCallers' => [$data['tankId'], $data['tankId']]]]),
             true
         );
-        $this->assertArraySubset(
+        $this->assertArrayContainsArray(
             ['dispatchRules.whitelistedCallers.0' => ['The dispatchRules.whitelistedCallers.0 field has a duplicate value.']],
             $response['error']
         );
@@ -223,7 +223,7 @@ class InsertRuleSetTest extends TestCaseGraphQL
             array_merge($data, ['dispatchRules' => ['whitelistedCallers' => [Str::random(300)]]]),
             true
         );
-        $this->assertArraySubset(
+        $this->assertArrayContainsArray(
             ['dispatchRules.whitelistedCallers.0' => ['The dispatchRules.whitelistedCallers.0 field must not be greater than 255 characters.']],
             $response['error']
         );
@@ -233,7 +233,7 @@ class InsertRuleSetTest extends TestCaseGraphQL
             array_merge($data, ['dispatchRules' => ['whitelistedCallers' => []]]),
             true
         );
-        $this->assertArraySubset(
+        $this->assertArrayContainsArray(
             ['dispatchRules.whitelistedCallers' => ['The dispatch rules.whitelisted callers field must have at least 1 items.']],
             $response['error']
         );
@@ -250,7 +250,7 @@ class InsertRuleSetTest extends TestCaseGraphQL
             array_merge($data, ['dispatchRules' => ['whitelistedCallers' => '']]),
             true
         );
-        $this->assertArraySubset(
+        $this->assertArrayContainsArray(
             ['dispatchRules.whitelistedCallers.0' => ['The dispatchRules.whitelistedCallers.0 field must have a value.']],
             $response['error']
         );
@@ -264,7 +264,7 @@ class InsertRuleSetTest extends TestCaseGraphQL
             array_merge($data, ['dispatchRules' => ['requireToken' => ['collectionId' => 1, 'tokenId' => ['integer' => 1]]]]),
             true
         );
-        $this->assertArraySubset(
+        $this->assertArrayContainsArray(
             ['dispatchRules.requireToken.collectionId' => ['The selected dispatch rules.require token.collection id is invalid.']],
             $response['error']
         );
@@ -294,7 +294,7 @@ class InsertRuleSetTest extends TestCaseGraphQL
             array_merge($data, ['dispatchRules' => ['requireToken' => ['collectionId' => Hex::MAX_UINT256 + 1, 'tokenId' => ['integer' => Hex::MAX_UINT256 + 1]]]]),
             true
         );
-        $this->assertArraySubset(
+        $this->assertArrayContainsArray(
             [
                 0 => [
                     'message' => 'Variable "$dispatchRules" got invalid value 1.1579208923732E+77 at "dispatchRules.requireToken.collectionId"; Cannot represent following value as uint256: 1.1579208923732E+77',
@@ -325,7 +325,7 @@ class InsertRuleSetTest extends TestCaseGraphQL
             array_merge($data, ['dispatchRules' => ['whitelistedCollections' => [1, 1]]]),
             true
         );
-        $this->assertArraySubset(
+        $this->assertArrayContainsArray(
             ['dispatchRules.whitelistedCollections.0' => ['The dispatchRules.whitelistedCollections.0 field has a duplicate value.']],
             $response['error']
         );
@@ -335,7 +335,7 @@ class InsertRuleSetTest extends TestCaseGraphQL
             array_merge($data, ['dispatchRules' => ['whitelistedCollections' => [5000]]]),
             true
         );
-        $this->assertArraySubset(
+        $this->assertArrayContainsArray(
             ['dispatchRules.whitelistedCollections.0' => ['The selected dispatchRules.whitelistedCollections.0 is invalid.']],
             $response['error']
         );
@@ -345,7 +345,7 @@ class InsertRuleSetTest extends TestCaseGraphQL
             array_merge($data, ['dispatchRules' => ['whitelistedCollections' => []]]),
             true
         );
-        $this->assertArraySubset(
+        $this->assertArrayContainsArray(
             ['dispatchRules.whitelistedCollections' => ['The dispatch rules.whitelisted collections field must have at least 1 items.']],
             $response['error']
         );
@@ -400,7 +400,7 @@ class InsertRuleSetTest extends TestCaseGraphQL
             array_merge($data, ['dispatchRules' => ['userFuelBudget' => ['amount' => 'Invalid', 'resetPeriod' => 'Invalid']]]),
             true
         );
-        $this->assertArraySubset(
+        $this->assertArrayContainsArray(
             [
                 0 => [
                     'message' => 'Variable "$dispatchRules" got invalid value "Invalid" at "dispatchRules.userFuelBudget.amount"; Cannot represent following value as uint256: "Invalid"',
@@ -417,7 +417,7 @@ class InsertRuleSetTest extends TestCaseGraphQL
             array_merge($data, ['dispatchRules' => ['userFuelBudget' => ['amount' => Hex::MAX_UINT256 + 1, 'resetPeriod' => Hex::MAX_UINT256 + 1]]]),
             true
         );
-        $this->assertArraySubset(
+        $this->assertArrayContainsArray(
             [
                 0 => [
                     'message' => 'Variable "$dispatchRules" got invalid value 1.1579208923732E+77 at "dispatchRules.userFuelBudget.amount"; Cannot represent following value as uint256: 1.1579208923732E+77',
@@ -438,7 +438,7 @@ class InsertRuleSetTest extends TestCaseGraphQL
             array_merge($data, ['dispatchRules' => ['tankFuelBudget' => ['amount' => 'Invalid', 'resetPeriod' => 'Invalid']]]),
             true
         );
-        $this->assertArraySubset(
+        $this->assertArrayContainsArray(
             [
                 0 => [
                     'message' => 'Variable "$dispatchRules" got invalid value "Invalid" at "dispatchRules.tankFuelBudget.amount"; Cannot represent following value as uint256: "Invalid"',
@@ -455,7 +455,7 @@ class InsertRuleSetTest extends TestCaseGraphQL
             array_merge($data, ['dispatchRules' => ['tankFuelBudget' => ['amount' => Hex::MAX_UINT256 + 1, 'resetPeriod' => Hex::MAX_UINT256 + 1]]]),
             true
         );
-        $this->assertArraySubset(
+        $this->assertArrayContainsArray(
             [
                 0 => [
                     'message' => 'Variable "$dispatchRules" got invalid value 1.1579208923732E+77 at "dispatchRules.tankFuelBudget.amount"; Cannot represent following value as uint256: 1.1579208923732E+77',

--- a/tests/Feature/GraphQL/Mutations/InsertRuleSetTest.php
+++ b/tests/Feature/GraphQL/Mutations/InsertRuleSetTest.php
@@ -87,6 +87,7 @@ class InsertRuleSetTest extends TestCaseGraphQL
                 'tankId' => resolve(SubstrateProvider::class)->public_key(),
                 'ruleSetId' => fake()->numberBetween(50000, 100000),
                 ...Arr::only($this->generateData(false), 'dispatchRules'),
+                'requireAccount' => true,
                 'skipValidation' => true,
             ]
         );
@@ -477,6 +478,7 @@ class InsertRuleSetTest extends TestCaseGraphQL
             'tankId' => $this->tank->public_key,
             'ruleSetId' => fake()->numberBetween(50000, 100000),
             ...Arr::only($this->generateData(false), 'dispatchRules'),
+            'requireAccount' => true,
         ];
     }
 }

--- a/tests/Feature/GraphQL/Mutations/MutateFuelTankTest.php
+++ b/tests/Feature/GraphQL/Mutations/MutateFuelTankTest.php
@@ -56,7 +56,7 @@ class MutateFuelTankTest extends TestCaseGraphQL
     {
         $data = $this->generateFuelTankData();
         $response = $this->graphql($this->method, array_merge($data, ['mutation' => []]), true);
-        $this->assertArraySubset(
+        $this->assertArrayContainsArray(
             ['mutation' => ['The mutation field is required.']],
             $response['error']
         );
@@ -70,7 +70,7 @@ class MutateFuelTankTest extends TestCaseGraphQL
             array_merge($data, ['tankId' => 'Invalid wallet address']),
             true
         );
-        $this->assertArraySubset(
+        $this->assertArrayContainsArray(
             ['tankId' => ['The selected tankId is invalid.']],
             $response['error']
         );
@@ -80,7 +80,7 @@ class MutateFuelTankTest extends TestCaseGraphQL
             array_merge($data, ['tankId' => Str::random(300)]),
             true
         );
-        $this->assertArraySubset(
+        $this->assertArrayContainsArray(
             ['tankId' => ['The tank id field must not be greater than 255 characters.']],
             $response['error']
         );
@@ -97,7 +97,7 @@ class MutateFuelTankTest extends TestCaseGraphQL
             array_merge($data, ['tankId' => '']),
             true
         );
-        $this->assertArraySubset(
+        $this->assertArrayContainsArray(
             ['tankId' => ['The tank id field must have a value.']],
             $response['error']
         );
@@ -143,7 +143,7 @@ class MutateFuelTankTest extends TestCaseGraphQL
         $invalidData = $data;
         Arr::set($invalidData, 'mutation.accountRules.whitelistedCallers', 'Invalid');
         $response = $this->graphql($this->method, $invalidData, true);
-        $this->assertArraySubset(
+        $this->assertArrayContainsArray(
             ['mutation.accountRules.whitelistedCallers.0' => ['The mutation.accountRules.whitelistedCallers.0 is not a valid substrate address.']],
             $response['error']
         );
@@ -151,7 +151,7 @@ class MutateFuelTankTest extends TestCaseGraphQL
         $invalidData = $data;
         Arr::set($invalidData, 'mutation.accountRules.whitelistedCallers', [$data['tankId'], $data['tankId']]);
         $response = $this->graphql($this->method, $invalidData, true);
-        $this->assertArraySubset(
+        $this->assertArrayContainsArray(
             [
                 'mutation.accountRules.whitelistedCallers.0' => ['The mutation.accountRules.whitelistedCallers.0 field has a duplicate value.'],
                 'mutation.accountRules.whitelistedCallers.1' => ['The mutation.accountRules.whitelistedCallers.1 field has a duplicate value.'],
@@ -162,7 +162,7 @@ class MutateFuelTankTest extends TestCaseGraphQL
         $invalidData = $data;
         Arr::set($invalidData, 'mutation.accountRules.whitelistedCallers', [Str::random(300)]);
         $response = $this->graphql($this->method, $invalidData, true);
-        $this->assertArraySubset(
+        $this->assertArrayContainsArray(
             ['mutation.accountRules.whitelistedCallers.0' => ['The mutation.accountRules.whitelistedCallers.0 field must not be greater than 255 characters.']],
             $response['error']
         );
@@ -170,7 +170,7 @@ class MutateFuelTankTest extends TestCaseGraphQL
         $invalidData = $data;
         Arr::set($invalidData, 'mutation.accountRules.whitelistedCallers', []);
         $response = $this->graphql($this->method, $invalidData, true);
-        $this->assertArraySubset(
+        $this->assertArrayContainsArray(
             ['mutation.accountRules.whitelistedCallers' => ['The mutation.account rules.whitelisted callers field must have at least 1 items.']],
             $response['error']
         );
@@ -183,7 +183,7 @@ class MutateFuelTankTest extends TestCaseGraphQL
         $invalidData = $data;
         Arr::set($invalidData, 'mutation.accountRules.whitelistedCallers', '');
         $response = $this->graphql($this->method, $invalidData, true);
-        $this->assertArraySubset(
+        $this->assertArrayContainsArray(
             ['mutation.accountRules.whitelistedCallers.0' => ['The mutation.accountRules.whitelistedCallers.0 field must have a value.']],
             $response['error']
         );
@@ -196,7 +196,7 @@ class MutateFuelTankTest extends TestCaseGraphQL
         $invalidData = $data;
         Arr::set($invalidData, 'mutation.accountRules.requireToken', ['collectionId' => 1, 'tokenId' => ['integer' => 1]]);
         $response = $this->graphql($this->method, $invalidData, true);
-        $this->assertArraySubset(
+        $this->assertArrayContainsArray(
             ['mutation.accountRules.requireToken.collectionId' => ['The selected mutation.account rules.require token.collection id is invalid.']],
             $response['error']
         );

--- a/tests/Feature/GraphQL/Mutations/MutateFuelTankTest.php
+++ b/tests/Feature/GraphQL/Mutations/MutateFuelTankTest.php
@@ -37,7 +37,7 @@ class MutateFuelTankTest extends TestCaseGraphQL
     {
         $response = $this->graphql($this->method, $params = [
             'tankId' => $this->createFuelTank()->public_key,
-            'mutation' => Arr::except($this->generateData(), ['name', 'account', 'dispatchRules']),
+            'mutation' => Arr::except($this->generateData(), ['name', 'account', 'dispatchRules', 'requireAccount']),
             'skipValidation' => true,
         ]);
 
@@ -233,7 +233,7 @@ class MutateFuelTankTest extends TestCaseGraphQL
     {
         return [
             'tankId' => $this->createFuelTank()->public_key,
-            'mutation' => Arr::except($this->generateData(), ['name', 'account', 'dispatchRules']),
+            'mutation' => Arr::except($this->generateData(), ['name', 'account', 'dispatchRules', 'requireAccount']),
         ];
     }
 }

--- a/tests/Feature/GraphQL/Mutations/RemoveAccountRuleDataTest.php
+++ b/tests/Feature/GraphQL/Mutations/RemoveAccountRuleDataTest.php
@@ -83,7 +83,7 @@ class RemoveAccountRuleDataTest extends TestCaseGraphQL
             array_merge($data, ['tankId' => $pubicKey]),
             true
         );
-        $this->assertArraySubset(
+        $this->assertArrayContainsArray(
             ['tankId' => ['The selected tankId is invalid.']],
             $response['error']
         );
@@ -93,7 +93,7 @@ class RemoveAccountRuleDataTest extends TestCaseGraphQL
             array_merge($data, ['tankId' => Str::random(300)]),
             true
         );
-        $this->assertArraySubset(
+        $this->assertArrayContainsArray(
             ['tankId' => ['The tank id field must not be greater than 255 characters.']],
             $response['error']
         );
@@ -103,7 +103,7 @@ class RemoveAccountRuleDataTest extends TestCaseGraphQL
             array_merge($data, ['tankId' => 'Invalid']),
             true
         );
-        $this->assertArraySubset(
+        $this->assertArrayContainsArray(
             ['tankId' => ['The tank id is not a valid substrate address.']],
             $response['error']
         );
@@ -124,7 +124,7 @@ class RemoveAccountRuleDataTest extends TestCaseGraphQL
             array_merge($data, ['tankId' => $tank->public_key]),
             true
         );
-        $this->assertArraySubset(
+        $this->assertArrayContainsArray(
             ['tankId' => ['The tank id provided is not owned by you.']],
             $response['error']
         );
@@ -140,7 +140,7 @@ class RemoveAccountRuleDataTest extends TestCaseGraphQL
             true
         );
 
-        $this->assertArraySubset(
+        $this->assertArrayContainsArray(
             ['userId' => ['The user id is not a valid substrate address.']],
             $response['error']
         );
@@ -157,7 +157,7 @@ class RemoveAccountRuleDataTest extends TestCaseGraphQL
             array_merge($data, ['userId' => Str::random(300)]),
             true
         );
-        $this->assertArraySubset(
+        $this->assertArrayContainsArray(
             ['userId' => ['The user id field must not be greater than 255 characters.']],
             $response['error']
         );
@@ -168,7 +168,7 @@ class RemoveAccountRuleDataTest extends TestCaseGraphQL
             array_merge($data, ['userId' => $pubicKey]),
             true
         );
-        $this->assertArraySubset(
+        $this->assertArrayContainsArray(
             ['userId' => ["The user id contains an account that doesn't exist in the fuel tank."]],
             $response['error']
         );

--- a/tests/Feature/GraphQL/Mutations/RemoveAccountTest.php
+++ b/tests/Feature/GraphQL/Mutations/RemoveAccountTest.php
@@ -75,7 +75,7 @@ class RemoveAccountTest extends TestCaseGraphQL
             ['tankId' => $pubicKey, 'userId' => $pubicKey],
             true
         );
-        $this->assertArraySubset(
+        $this->assertArrayContainsArray(
             ['tankId' => ['The selected tankId is invalid.']],
             $response['error']
         );
@@ -85,7 +85,7 @@ class RemoveAccountTest extends TestCaseGraphQL
             ['tankId' => Str::random(300), 'userId' => $pubicKey],
             true
         );
-        $this->assertArraySubset(
+        $this->assertArrayContainsArray(
             ['tankId' => ['The tank id field must not be greater than 255 characters.']],
             $response['error']
         );
@@ -95,7 +95,7 @@ class RemoveAccountTest extends TestCaseGraphQL
             ['tankId' => 'Invalid', 'userId' => $pubicKey],
             true
         );
-        $this->assertArraySubset(
+        $this->assertArrayContainsArray(
             ['tankId' => ['The tank id is not a valid substrate address.']],
             $response['error']
         );
@@ -116,7 +116,7 @@ class RemoveAccountTest extends TestCaseGraphQL
             ['tankId' => $tank->public_key, 'userId' => $pubicKey],
             true
         );
-        $this->assertArraySubset(
+        $this->assertArrayContainsArray(
             ['tankId' => ['The tank id provided is not owned by you.']],
             $response['error']
         );
@@ -129,7 +129,7 @@ class RemoveAccountTest extends TestCaseGraphQL
             ['tankId' => $this->tank->public_key, 'userId' => 'Invalid'],
             true
         );
-        $this->assertArraySubset(
+        $this->assertArrayContainsArray(
             ['userId' => ['The user id is not a valid substrate address.']],
             $response['error']
         );
@@ -149,7 +149,7 @@ class RemoveAccountTest extends TestCaseGraphQL
             ['tankId' => $this->tank->public_key, 'userId' => Str::random(300)],
             true
         );
-        $this->assertArraySubset(
+        $this->assertArrayContainsArray(
             ['userId' => ['The user id field must not be greater than 255 characters.']],
             $response['error']
         );
@@ -160,7 +160,7 @@ class RemoveAccountTest extends TestCaseGraphQL
             ['tankId' => $this->tank->public_key, 'userId' => $this->account],
             true
         );
-        $this->assertArraySubset(
+        $this->assertArrayContainsArray(
             ['userId' => ["The user id contains an account that doesn't exist in the fuel tank."]],
             $response['error']
         );

--- a/tests/Feature/GraphQL/Mutations/RemoveRuleSetTest.php
+++ b/tests/Feature/GraphQL/Mutations/RemoveRuleSetTest.php
@@ -68,7 +68,7 @@ class RemoveRuleSetTest extends TestCaseGraphQL
             ['tankId' => $pubicKey, 'ruleSetId' => 1],
             true
         );
-        $this->assertArraySubset(
+        $this->assertArrayContainsArray(
             ['tankId' => ['The selected tankId is invalid.']],
             $response['error']
         );
@@ -78,7 +78,7 @@ class RemoveRuleSetTest extends TestCaseGraphQL
             ['tankId' => Str::random(300), 'ruleSetId' => 1],
             true
         );
-        $this->assertArraySubset(
+        $this->assertArrayContainsArray(
             ['tankId' => ['The tank id field must not be greater than 255 characters.']],
             $response['error']
         );
@@ -88,7 +88,7 @@ class RemoveRuleSetTest extends TestCaseGraphQL
             ['tankId' => 'Invalid', 'ruleSetId' => 1],
             true
         );
-        $this->assertArraySubset(
+        $this->assertArrayContainsArray(
             ['tankId' => ['The tank id is not a valid substrate address.']],
             $response['error']
         );
@@ -109,7 +109,7 @@ class RemoveRuleSetTest extends TestCaseGraphQL
             ['tankId' => $tank->public_key, 'ruleSetId' => 1],
             true
         );
-        $this->assertArraySubset(
+        $this->assertArrayContainsArray(
             ['tankId' => ['The tank id provided is not owned by you.']],
             $response['error']
         );
@@ -152,7 +152,7 @@ class RemoveRuleSetTest extends TestCaseGraphQL
             ['tankId' => $this->tank->public_key, 'ruleSetId' => fake()->numberBetween(5000, 10000)],
             true
         );
-        $this->assertArraySubset(
+        $this->assertArrayContainsArray(
             ['ruleSetId' => ["The rule set ID doesn't exist."]],
             $response['error']
         );

--- a/tests/Feature/GraphQL/Mutations/ScheduleMutateFreezeStateTest.php
+++ b/tests/Feature/GraphQL/Mutations/ScheduleMutateFreezeStateTest.php
@@ -84,7 +84,7 @@ class ScheduleMutateFreezeStateTest extends TestCaseGraphQL
             array_merge($data, ['tankId' => $pubicKey]),
             true
         );
-        $this->assertArraySubset(
+        $this->assertArrayContainsArray(
             ['tankId' => ['The selected tankId is invalid.']],
             $response['error']
         );
@@ -95,7 +95,7 @@ class ScheduleMutateFreezeStateTest extends TestCaseGraphQL
             array_merge($data, ['tankId' => Str::random(300)]),
             true
         );
-        $this->assertArraySubset(
+        $this->assertArrayContainsArray(
             ['tankId' => ['The tank id field must not be greater than 255 characters.']],
             $response['error']
         );
@@ -105,7 +105,7 @@ class ScheduleMutateFreezeStateTest extends TestCaseGraphQL
             array_merge($data, ['tankId' => 'Invalid']),
             true
         );
-        $this->assertArraySubset(
+        $this->assertArrayContainsArray(
             ['tankId' => ['The tank id is not a valid substrate address.']],
             $response['error']
         );
@@ -126,7 +126,7 @@ class ScheduleMutateFreezeStateTest extends TestCaseGraphQL
             array_merge($data, ['tankId' => $tank->public_key]),
             true
         );
-        $this->assertArraySubset(
+        $this->assertArrayContainsArray(
             ['tankId' => ['The tank id provided is not owned by you.']],
             $response['error']
         );
@@ -167,7 +167,7 @@ class ScheduleMutateFreezeStateTest extends TestCaseGraphQL
             array_merge($data, ['ruleSetId' => fake()->numberBetween(5000, 10000)]),
             true
         );
-        $this->assertArraySubset(
+        $this->assertArrayContainsArray(
             ['ruleSetId' => ["The rule set ID doesn't exist."]],
             $response['error']
         );

--- a/tests/Feature/GraphQL/Mutations/SetConsumptionTest.php
+++ b/tests/Feature/GraphQL/Mutations/SetConsumptionTest.php
@@ -84,7 +84,7 @@ class SetConsumptionTest extends TestCaseGraphQL
             array_merge($data, ['tankId' => $pubicKey]),
             true
         );
-        $this->assertArraySubset(
+        $this->assertArrayContainsArray(
             ['tankId' => ['The selected tankId is invalid.']],
             $response['error']
         );
@@ -94,7 +94,7 @@ class SetConsumptionTest extends TestCaseGraphQL
             array_merge($data, ['tankId' => Str::random(300)]),
             true
         );
-        $this->assertArraySubset(
+        $this->assertArrayContainsArray(
             ['tankId' => ['The tank id field must not be greater than 255 characters.']],
             $response['error']
         );
@@ -104,7 +104,7 @@ class SetConsumptionTest extends TestCaseGraphQL
             array_merge($data, ['tankId' => 'Invalid']),
             true
         );
-        $this->assertArraySubset(
+        $this->assertArrayContainsArray(
             ['tankId' => ['The tank id is not a valid substrate address.']],
             $response['error']
         );
@@ -125,7 +125,7 @@ class SetConsumptionTest extends TestCaseGraphQL
             array_merge($data, ['tankId' => $tank->public_key]),
             true
         );
-        $this->assertArraySubset(
+        $this->assertArrayContainsArray(
             ['tankId' => ['The tank id provided is not owned by you.']],
             $response['error']
         );
@@ -139,7 +139,7 @@ class SetConsumptionTest extends TestCaseGraphQL
             array_merge($data, ['userId' => 'Invalid']),
             true
         );
-        $this->assertArraySubset(
+        $this->assertArrayContainsArray(
             ['userId' => ['The user id is not a valid substrate address.']],
             $response['error']
         );
@@ -156,7 +156,7 @@ class SetConsumptionTest extends TestCaseGraphQL
             array_merge($data, ['userId' => Str::random(300)]),
             true
         );
-        $this->assertArraySubset(
+        $this->assertArrayContainsArray(
             ['userId' => ['The user id field must not be greater than 255 characters.']],
             $response['error']
         );
@@ -167,7 +167,7 @@ class SetConsumptionTest extends TestCaseGraphQL
             array_merge($data, ['userId' => $pubicKey]),
             true
         );
-        $this->assertArraySubset(
+        $this->assertArrayContainsArray(
             ['userId' => ["The user id contains an account that doesn't exist in the fuel tank."]],
             $response['error']
         );
@@ -211,7 +211,7 @@ class SetConsumptionTest extends TestCaseGraphQL
             array_merge($data, ['ruleSetId' => fake()->numberBetween(5000, 10000)]),
             true
         );
-        $this->assertArraySubset(
+        $this->assertArrayContainsArray(
             ['ruleSetId' => ["The rule set ID doesn't exist."]],
             $response['error']
         );

--- a/tests/Feature/GraphQL/Queries/GetAccountsTest.php
+++ b/tests/Feature/GraphQL/Queries/GetAccountsTest.php
@@ -46,19 +46,19 @@ class GetAccountsTest extends TestCaseGraphQL
         );
 
         $response = $this->graphql($this->method, ['tankId' => ''], true);
-        $this->assertArraySubset(
+        $this->assertArrayContainsArray(
             ['tankId' => ['The tank id field must have a value.']],
             $response['error']
         );
 
         $response = $this->graphql($this->method, ['tankId' => Str::random(10)], true);
-        $this->assertArraySubset(
+        $this->assertArrayContainsArray(
             ['tankId' => ['The tank id is not a valid substrate address.']],
             $response['error']
         );
 
         $response = $this->graphql($this->method, ['tankId' => Str::random(300)], true);
-        $this->assertArraySubset(
+        $this->assertArrayContainsArray(
             ['tankId' => ['The tank id field must not be greater than 255 characters.']],
             $response['error']
         );
@@ -68,7 +68,7 @@ class GetAccountsTest extends TestCaseGraphQL
             ['tankId' => resolve(SubstrateProvider::class)->public_key()],
             true
         );
-        $this->assertArraySubset(
+        $this->assertArrayContainsArray(
             ['tankId' => ['The selected tankId is invalid.']],
             $response['error']
         );

--- a/tests/Feature/GraphQL/Queries/GetFuelTankTest.php
+++ b/tests/Feature/GraphQL/Queries/GetFuelTankTest.php
@@ -38,7 +38,7 @@ class GetFuelTankTest extends TestCaseGraphQL
     public function test_it_will_fail_with_invalid_name(): void
     {
         $response = $this->graphql($this->method, ['name' => null], true);
-        $this->assertArraySubset(
+        $this->assertArrayContainsArray(
             [
                 'name' => ['The name field is required when tank id is not present.'],
                 'tankId' => ['The tank id field is required when name is not present.'],
@@ -47,19 +47,19 @@ class GetFuelTankTest extends TestCaseGraphQL
         );
 
         $response = $this->graphql($this->method, ['name' => ''], true);
-        $this->assertArraySubset(
+        $this->assertArrayContainsArray(
             ['name' => ['The name field is required when tank id is not present.']],
             $response['error']
         );
 
         $response = $this->graphql($this->method, ['name' => Str::random(50)], true);
-        $this->assertArraySubset(
+        $this->assertArrayContainsArray(
             ['name' => ['The name field must not be greater than 32 characters.']],
             $response['error']
         );
 
         $response = $this->graphql($this->method, ['name' => Str::random(6)], true);
-        $this->assertArraySubset(
+        $this->assertArrayContainsArray(
             ['name' => ['The selected name is invalid.']],
             $response['error']
         );
@@ -68,7 +68,7 @@ class GetFuelTankTest extends TestCaseGraphQL
     public function test_it_will_fail_with_invalid_tank_id(): void
     {
         $response = $this->graphql($this->method, ['tankId' => null], true);
-        $this->assertArraySubset(
+        $this->assertArrayContainsArray(
             [
                 'name' => ['The name field is required when tank id is not present.'],
                 'tankId' => ['The tank id field is required when name is not present.'],
@@ -77,13 +77,13 @@ class GetFuelTankTest extends TestCaseGraphQL
         );
 
         $response = $this->graphql($this->method, ['tankId' => ''], true);
-        $this->assertArraySubset(
+        $this->assertArrayContainsArray(
             ['tankId' => ['The tank id field is required when name is not present.']],
             $response['error']
         );
 
         $response = $this->graphql($this->method, ['tankId' => Str::random(50)], true);
-        $this->assertArraySubset(
+        $this->assertArrayContainsArray(
             ['tankId' => ['The tank id is not a valid substrate address.']],
             $response['error']
         );
@@ -93,7 +93,7 @@ class GetFuelTankTest extends TestCaseGraphQL
             ['tankId' => resolve(SubstrateProvider::class)->public_key()],
             true
         );
-        $this->assertArraySubset(
+        $this->assertArrayContainsArray(
             ['tankId' => ['The selected tankId is invalid.']],
             $response['error']
         );

--- a/tests/Feature/GraphQL/Queries/GetFuelTanksTest.php
+++ b/tests/Feature/GraphQL/Queries/GetFuelTanksTest.php
@@ -48,19 +48,19 @@ class GetFuelTanksTest extends TestCaseGraphQL
     public function test_it_will_fail_with_invalid_names(): void
     {
         $response = $this->graphql($this->method, ['names' => ['']], true);
-        $this->assertArraySubset(
+        $this->assertArrayContainsArray(
             ['names.0' => ['The names.0 field must have a value.']],
             $response['error']
         );
 
         $response = $this->graphql($this->method, ['names' => [Str::random(50)]], true);
-        $this->assertArraySubset(
+        $this->assertArrayContainsArray(
             ['names.0' => ['The names.0 field must not be greater than 32 characters.']],
             $response['error']
         );
 
         $response = $this->graphql($this->method, ['names' => ['duplicate', 'duplicate']], true);
-        $this->assertArraySubset(
+        $this->assertArrayContainsArray(
             ['names.0' => ['The names.0 field has a duplicate value.']],
             $response['error']
         );
@@ -69,19 +69,19 @@ class GetFuelTanksTest extends TestCaseGraphQL
     public function test_it_will_fail_with_invalid_tank_ids(): void
     {
         $response = $this->graphql($this->method, ['tankIds' => ['']], true);
-        $this->assertArraySubset(
+        $this->assertArrayContainsArray(
             ['tankIds.0' => ['The tankIds.0 field must have a value.']],
             $response['error']
         );
 
         $response = $this->graphql($this->method, ['tankIds' => [Str::random(50)]], true);
-        $this->assertArraySubset(
+        $this->assertArrayContainsArray(
             ['tankIds.0' => ['The tankIds.0 is not a valid substrate address.']],
             $response['error']
         );
 
         $response = $this->graphql($this->method, ['tankIds' => ['duplicate', 'duplicate']], true);
-        $this->assertArraySubset(
+        $this->assertArrayContainsArray(
             ['tankIds.0' => ['The tankIds.0 field has a duplicate value.']],
             $response['error']
         );

--- a/tests/Feature/GraphQL/Resources/CreateFuelTank.graphql
+++ b/tests/Feature/GraphQL/Resources/CreateFuelTank.graphql
@@ -4,6 +4,7 @@ mutation CreateFuelTank(
   $coveragePolicy: CoveragePolicy
   $accountRules: AccountRuleInputType
   $dispatchRules: [DispatchRuleInputType!]
+  $requireAccount: Boolean
   $skipValidation: Boolean
 ) {
   CreateFuelTank(
@@ -12,6 +13,7 @@ mutation CreateFuelTank(
     coveragePolicy: $coveragePolicy
     accountRules: $accountRules
     dispatchRules: $dispatchRules
+    requireAccount: $requireAccount
     skipValidation: $skipValidation
   ) {
     id

--- a/tests/Feature/GraphQL/TestCaseGraphQL.php
+++ b/tests/Feature/GraphQL/TestCaseGraphQL.php
@@ -2,7 +2,6 @@
 
 namespace Enjin\Platform\FuelTanks\Tests\Feature\GraphQL;
 
-use DMS\PHPUnitExtensions\ArraySubset\ArraySubsetAsserts;
 use Enjin\Platform\CoreServiceProvider;
 use Enjin\Platform\FuelTanks\FuelTanksServiceProvider;
 use Enjin\Platform\FuelTanks\Models\DispatchRule;
@@ -21,7 +20,6 @@ use Rebing\GraphQL\Support\Facades\GraphQL;
 
 class TestCaseGraphQL extends BaseTestCase
 {
-    use ArraySubsetAsserts;
     use CreateCollectionData;
     use GenerateFuelTankData;
 
@@ -239,6 +237,16 @@ class TestCaseGraphQL extends BaseTestCase
         if ($this->fakeEvents) {
             Event::fake();
         }
+    }
+
+    protected function assertArrayContainsArray(array $expected, array $actual): void
+    {
+        $this->assertArrayIsEqualToArrayOnlyConsideringListOfKeys($expected, $actual, $this->arrayKeys($expected));
+    }
+
+    protected function arrayKeys($array): array
+    {
+        return array_keys(Arr::dot($array));
     }
 
     /**

--- a/tests/Feature/GraphQL/Traits/GenerateFuelTankData.php
+++ b/tests/Feature/GraphQL/Traits/GenerateFuelTankData.php
@@ -40,6 +40,7 @@ trait GenerateFuelTankData
                 ],
             ],
             'dispatchRules' => $isArray ? [$dispatchRules] : $dispatchRules,
+            'requireAccount' => true,
         ];
     }
 }


### PR DESCRIPTION
### **PR Type**
Enhancement, Tests


___

### **Description**
- Added a new `requireAccount` argument to the `CreateFuelTank` mutation with a default value of `false`.
- Implemented validation rules to prohibit `userFuelBudget` unless `requireAccount` is true.
- Replaced deprecated `assertArraySubset` with `assertArrayContainsArray` across multiple test files.
- Introduced a new helper method `assertArrayContainsArray` in `TestCaseGraphQL` and removed the `ArraySubsetAsserts` trait.
- Updated dependencies in `composer.json`, including removing `dms/phpunit-arraysubset-asserts` and upgrading PHPUnit and Rector versions.



___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>CreateFuelTankMutation.php</strong><dd><code>Add `requireAccount` argument to CreateFuelTank mutation.</code></dd></summary>
<hr>

src/GraphQL/Mutations/CreateFuelTankMutation.php

<li>Added <code>requireAccount</code> argument with default value <code>false</code>.<br> <li> Updated <code>resolve</code> method to include <code>requireAccount</code> in encoded data.<br> <li> Modified <code>getEncodableParams</code> to handle <code>requireAccount</code>.<br>


</details>


  </td>
  <td><a href="https://github.com/enjin/platform-fuel-tanks/pull/77/files#diff-db0576a64d2ce59dfac4687e0bb972f3cafca8f05b45531ec30854a04e21fc66">+8/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>HasFuelTankValidationRules.php</strong><dd><code>Add validation rule for `userFuelBudget` based on `requireAccount`.</code></dd></summary>
<hr>

src/GraphQL/Traits/HasFuelTankValidationRules.php

<li>Added validation rule to prohibit <code>userFuelBudget</code> unless <code>requireAccount</code> <br>is true.<br>


</details>


  </td>
  <td><a href="https://github.com/enjin/platform-fuel-tanks/pull/77/files#diff-3187c469141b77d0487fca097b26ad282af384206e381274380f9da023986ffa">+2/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Tests</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>AddAccountTest.php</strong><dd><code>Update assertions in AddAccountTest.</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

tests/Feature/GraphQL/Mutations/AddAccountTest.php

- Replaced `assertArraySubset` with `assertArrayContainsArray`.



</details>


  </td>
  <td><a href="https://github.com/enjin/platform-fuel-tanks/pull/77/files#diff-ab0a0f31060792f94b5b010864260924d88d74f6cd005bbf3a9ba2438982b7d7">+7/-7</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>BatchAddAccountTest.php</strong><dd><code>Update assertions in BatchAddAccountTest.</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

tests/Feature/GraphQL/Mutations/BatchAddAccountTest.php

- Replaced `assertArraySubset` with `assertArrayContainsArray`.



</details>


  </td>
  <td><a href="https://github.com/enjin/platform-fuel-tanks/pull/77/files#diff-23f4f9d9b6cfd0c7dec0bc01ad3222376e2f22dfd6263691878230998b362f65">+10/-10</a>&nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>CreateFuelTankTest.php</strong><dd><code>Update assertions in CreateFuelTankTest.</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

tests/Feature/GraphQL/Mutations/CreateFuelTankTest.php

- Replaced `assertArraySubset` with `assertArrayContainsArray`.



</details>


  </td>
  <td><a href="https://github.com/enjin/platform-fuel-tanks/pull/77/files#diff-f0ef857472ad49a396277435ce5ba37371da5b20a89cbcc87525da918313d17d">+24/-24</a>&nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>TestCaseGraphQL.php</strong><dd><code>Refactor TestCaseGraphQL to remove deprecated assertions.</code></dd></summary>
<hr>

tests/Feature/GraphQL/TestCaseGraphQL.php

<li>Removed <code>ArraySubsetAsserts</code> trait.<br> <li> Added <code>assertArrayContainsArray</code> helper method.<br>


</details>


  </td>
  <td><a href="https://github.com/enjin/platform-fuel-tanks/pull/77/files#diff-64046e35e5b2c6c1ed8fd54dc8e74d5e72341f1205f6cdfbb7f93b2b7d1e60ad">+10/-2</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Dependencies</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>composer.json</strong><dd><code>Update dependencies in composer.json.</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

composer.json

<li>Removed <code>dms/phpunit-arraysubset-asserts</code> dependency.<br> <li> Updated <code>rector/rector</code> and PHPUnit dependencies to newer versions.<br>


</details>


  </td>
  <td><a href="https://github.com/enjin/platform-fuel-tanks/pull/77/files#diff-d2ab9925cad7eac58e0ff4cc0d251a937ecf49e4b6bf57f8b95aab76648a9d34">+6/-7</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

___

> 💡 **PR-Agent usage**: Comment `/help "your question"` on any pull request to receive relevant information