### PR TITLE
[PLA-2230] Only unprefix if not null

### DIFF
--- a/src/GraphQL/Mutations/DispatchMutation.php
+++ b/src/GraphQL/Mutations/DispatchMutation.php
@@ -139,7 +139,7 @@ class DispatchMutation extends Mutation implements PlatformBlockchainTransaction
             ruleSetId: $args['ruleSetId'],
         ));
 
-        $encodedCall .= HexConverter::unPrefix($rawCall) ?: static::getEncodedCall($args);
+        $encodedCall .= $rawCall ? HexConverter::unPrefix($rawCall) : static::getEncodedCall($args);
 
         return $encodedCall . TransactionSerializer::encodeRaw(
             'OptionDispatchSettings',


### PR DESCRIPTION
### **PR Type**
- Bug fix



___

### **Description**
- Correct rawCall condition in DispatchMutation.php.

- Use conditional operator to avoid unPrefix on null.


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>DispatchMutation.php</strong><dd><code>Update rawCall conditional logic for bug fix.</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/GraphQL/Mutations/DispatchMutation.php

<li>Replaced null coalesce operator with conditional ternary.<br> <li> Ensured correct branch logic on rawCall.


</details>


  </td>
  <td><a href="https://github.com/enjin/platform-fuel-tanks/pull/89/files#diff-87f5723a43a071591665152b45c9e01f47f2c3fa3317c936d45d5477cdaf9977">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

___

> <details> <summary>  Need help?</summary><li>Type <code>/help how to ...</code> in the comments thread for any questions about PR-Agent usage.</li><li>Check out the <a href="https://qodo-merge-docs.qodo.ai/usage-guide/">documentation</a> for more information.</li></details>